### PR TITLE
Post-DDL DML Cache Invalidation in `DeviceEventStreamer`

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
@@ -1314,6 +1314,14 @@ public class DeviceEventStreamer extends DeviceProcessor {
 							default:
 								break;
 							}
+							// Invalidate DML operation caches for this table. DDL may have changed the
+							// table schema (ADDCOLUMN, DROPCOLUMN, ALTERCOLUMN, REFRESHTABLE, etc.), and
+							// any previously-cached mapped INSERT/UPDATE/DELETE would generate stale SQL
+							// with wrong columns (e.g. INSERT including a dropped column, or missing a
+							// newly added column). Removing forces rebuild from the updated srcTable schema.
+							tblMappedInsertOpers.remove(srcTable.id);
+							tblMappedUpdateOpers.remove(srcTable.id);
+							tblMappedDeleteOpers.remove(srcTable.id);
 							updateDstCheckpointIfNeeded(dstExecutor, log.commitId, log.changeNumber, log.txnChangeNumber, beforeValues, afterValues);
 							beforeValues.clear();
 							afterValues.clear();


### PR DESCRIPTION
# PR: Post-DDL DML Cache Invalidation in `DeviceEventStreamer`

## Files Changed

- `root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java`

---

## Root Cause

`doApply()` maintains three per-table caches of pre-built mapped DML operations:

- `tblMappedInsertOpers`
- `tblMappedUpdateOpers`
- `tblMappedDeleteOpers`

These caches are keyed by `srcTable.id` and hold a mapped operation containing the destination table's column list at the time of first use — an optimisation to avoid re-creating the mapped operation for every repeated INSERT/UPDATE/DELETE on the same table within a segment.

When a DDL event (ADDCOLUMN, DROPCOLUMN, ALTERCOLUMN, REFRESHTABLE, RENAMECOLUMN, etc.) is processed mid-segment, the `srcTable` schema is updated in-memory to reflect the new structure. However, the DML cache entries for that table were **never invalidated**. Any subsequent DML on the same table within the same segment reused the stale mapped operation — one built against the old, pre-DDL schema.

## Concrete Failure Sequence

Device `synclite-testdbreader-be1343df` (REPLICATION mode):

```
cn=4  INSERT test_dbreader (19 cols incl. col_clob) → DML cache populated: mapped INSERT with col_clob
cn=5  INSERT test_dbreader                          → cache hit, same stale mapped INSERT reused
cn=8  ADDCOLUMN  ADD col_new                        → srcTable schema updated: +col_new
cn=9  DROPCOLUMN DROP col_clob                      → srcTable schema updated: -col_clob
cn=10 REFRESHTABLE                                  → srcTable refreshed to final 19-col schema (no col_clob, has col_new)
cn=11 INSERT test_dbreader (19 new cols)             → cache hit! stale mapped INSERT still references col_clob
                                                    → org.sqlite.SQLiteException: table has no column named col_clob
```

**Why restart fixed it:** On restart, `reloadCheckpointInfo()` calls `consolidatorMetadataMgr.loadSchemas()` which loads the final persisted schema (written by REFRESHTABLE's `upsertSchema()` call into the metadata DB). The DDL ops at cn=8–10 all return `null` from `generate*Oper()` (no delta to apply — schema already matches), so no DML cache entry is ever built against the old schema. The cn=11 INSERT then creates a fresh cache entry from the correct schema. Hence the job succeeds on restart but fails on first run.

## Fix

After the DDL `switch` block in `doApply()`, explicitly remove the affected table from all three DML caches before processing the next record:

```java
// Invalidate DML operation caches for this table. DDL may have changed the
// table schema (ADDCOLUMN, DROPCOLUMN, ALTERCOLUMN, REFRESHTABLE, etc.), and
// any previously-cached mapped INSERT/UPDATE/DELETE would generate stale SQL
// with wrong columns (e.g. INSERT including a dropped column, or missing a
// newly added column). Removing forces rebuild from the updated srcTable schema.
tblMappedInsertOpers.remove(srcTable.id);
tblMappedUpdateOpers.remove(srcTable.id);
tblMappedDeleteOpers.remove(srcTable.id);
```

This forces the next DML on that table to rebuild the mapped operation from the updated `srcTable` schema, ensuring INSERT/UPDATE/DELETE SQL and column bindings reflect the post-DDL structure.
