### PR TITLE
Startup Stability, Logging Overhead Reduction, and Build Pipeline Cle…

### DIFF
--- a/root/core/.classpath
+++ b/root/core/.classpath
@@ -59,16 +59,5 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path=".apt_generated">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path=".apt_generated_tests">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/root/core/pom.xml
+++ b/root/core/pom.xml
@@ -175,6 +175,7 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
+							<attach>false</attach>
 							<appendAssemblyId>false</appendAssemblyId>
 							<finalName>consolidator</finalName>
 							<descriptors>
@@ -185,24 +186,33 @@
 				</executions>
 			</plugin>
 
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>2.0.0</version>
-				<executions>
-					<execution>
-						<id>generate-third-party-report</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>download-licenses</goal>
-							<goal>third-party-report</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>license-report</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>license-maven-plugin</artifactId>
+						<version>2.0.0</version>
+						<executions>
+							<execution>
+								<id>generate-third-party-report</id>
+								<phase>prepare-package</phase>
+								<goals>
+									<goal>download-licenses</goal>
+									<goal>third-party-report</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<dependencies>
 
@@ -265,28 +275,18 @@
 			<version>5.1.0</version>
 		</dependency>
 
-		<!-- Log4j 2.x with 1.x API bridge for backward compatibility -->
+		<!-- reload4j: CVE-clean drop-in replacement for log4j 1.x (no bridge chain overhead) -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-1.2-api</artifactId>
-			<version>2.24.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.24.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.24.3</version>
+			<groupId>ch.qos.reload4j</groupId>
+			<artifactId>reload4j</artifactId>
+			<version>1.2.25</version>
 		</dependency>
 
-		<!-- SLF4J bridge to route SLF4J calls (from HikariCP etc.) through Log4j 2.x -->
+		<!-- SLF4J bridge to route SLF4J calls (from HikariCP etc.) through reload4j -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.24.3</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-reload4j</artifactId>
+			<version>2.0.17</version>
 		</dependency>
 
 		<dependency>

--- a/root/core/src/main/java/com/synclite/consolidator/SyncDriver.java
+++ b/root/core/src/main/java/com/synclite/consolidator/SyncDriver.java
@@ -339,6 +339,7 @@ public class SyncDriver implements Runnable{
 	}
 
 	private final void detectNewDevices() {
+		globalTracer.info("DEVICE-DETECTOR: Thread started");
 		while (!Thread.currentThread().isInterrupted()) {
 			try {
 				if (deviceParentWatcher != null) {
@@ -349,7 +350,9 @@ public class SyncDriver implements Runnable{
 				Path deviceDataRoot = ConfLoader.getInstance().getDeviceDataRoot();
 				//Watch all device parents and also device directories individually
 
-				for (Path deviceParent : locator.getAllDeviceParents()) {
+				Set<Path> parents = locator.getAllDeviceParents();
+				globalTracer.debug("DEVICE-DETECTOR: Registering " + parents.size() + " parent directories for watching: " + parents);
+				for (Path deviceParent : parents) {
 					deviceParent.register(deviceParentWatcher, StandardWatchEventKinds.ENTRY_CREATE);	
 				}
 
@@ -362,11 +365,14 @@ public class SyncDriver implements Runnable{
 						for (WatchEvent<?> event : key.pollEvents()) {
 							String detectedDevice = event.context().toString();
 							Path detectedDevicePathInUpload = Path.of(detectedParent.toString(), detectedDevice);
+							globalTracer.debug("DEVICE-DETECTOR: FS event in parent='" + detectedParent + "' entry='" + detectedDevice + "' fullPath='" + detectedDevicePathInUpload + "'");
 							if (!detectedDevicePathInUpload.toFile().isDirectory()) {
+								globalTracer.debug("DEVICE-DETECTOR: SKIP — not a directory: " + detectedDevicePathInUpload);
 								continue;
 							}					
 							if (Device.validateDeviceDataRoot(detectedDevicePathInUpload) == null) {
 								//Watch this directory as this may be a nested parent for devices to be created in future
+								globalTracer.debug("DEVICE-DETECTOR: Not a device root, registering as potential device parent: " + detectedDevicePathInUpload);
 								detectedDevicePathInUpload.register(deviceParentWatcher, StandardWatchEventKinds.ENTRY_CREATE);
 							}
 							//Check if device exists in deviceDataRoot and if does not exists then create it
@@ -375,13 +381,16 @@ public class SyncDriver implements Runnable{
 							Files.createDirectories(detectedDevicePathInDataRoot);
 							Device device = this.locator.locateDeviceAtPath(detectedDevicePathInDataRoot, detectedDevicePathInUpload);
 							if (device != null) {
+								globalTracer.debug("DEVICE-DETECTOR: Device located: " + device.getDeviceUUID() + " (" + device.getDeviceName() + ") status=" + device.getStatus());
 								if ((devices.size() + failedDevices.size()) < ConfLoader.getInstance().getDeviceCountLimit()) {
 									if (!devices.contains(device) && !failedDevices.contains(device)) {
 										//Add the new device to devices, registerDevices will try to register it  
-										//globalLogger.info("New : " + detectedDevice);
 										this.devices.add(device);
+										globalTracer.info("DEVICE-DETECTOR: New device added to live set: " + device.getDeviceUUID() + " (" + device.getDeviceName() + "). Total devices=" + this.devices.size());
 										Monitor.getInstance().setDetectedDeviceCnt(this.devices.size() + this.failedDevices.size());
 										Monitor.getInstance().setFailedDeviceCnt(this.failedDevices.size());
+									} else {
+										globalTracer.debug("DEVICE-DETECTOR: Device already in set, skipping: " + device.getDeviceUUID());
 									}
 								} else {
 									globalTracer.error("Device count exceeded the specified limit of " + ConfLoader.getInstance().getDeviceCountLimit() + ". Please renew your license.");
@@ -394,7 +403,9 @@ public class SyncDriver implements Runnable{
 								//Register this device's parent as well for watching
 								device.getDeviceUploadRoot().register(deviceParentWatcher, StandardWatchEventKinds.ENTRY_CREATE);
 
-							}						
+							} else {
+								globalTracer.debug("DEVICE-DETECTOR: locateDeviceAtPath returned null for: " + detectedDevicePathInDataRoot);
+							}
 						}
 						poll = key.reset();				
 					} catch (Exception e) {
@@ -486,7 +497,9 @@ public class SyncDriver implements Runnable{
 
 	private final void locateNewDevices() {
 		try {
+			globalTracer.debug("LOCATE-NEW: Scanning for new devices from uploadRoot=" + ConfLoader.getInstance().getDeviceUploadRoot() + ". Current devices=" + devices.size() + " failed=" + failedDevices.size());
 			Set<Device> allDevices = locator.listDevices(ConfLoader.getInstance().getDeviceUploadRoot());
+			globalTracer.debug("LOCATE-NEW: Stage scan found " + allDevices.size() + " total devices");
 			Set<Device> newDevices = new HashSet<Device>();
 			long latestDeviceCount = allDevices.size();
 			if (latestDeviceCount > ConfLoader.getInstance().getDeviceCountLimit()) {
@@ -497,6 +510,7 @@ public class SyncDriver implements Runnable{
 					if (!devices.contains(device) && !failedDevices.contains(device)) {
 						++latestDeviceCount;
 						newDevices.add(device);
+						globalTracer.debug("LOCATE-NEW: New device found: " + device.getDeviceUUID() + " (" + device.getDeviceName() + ") status=" + device.getStatus());
 						if (latestDeviceCount > ConfLoader.getInstance().getDeviceCountLimit()) {
 							globalTracer.error("Device count exceeded the specified limit of " + ConfLoader.getInstance().getDeviceCountLimit() + ". Please renew your license.");
 							break;
@@ -505,9 +519,11 @@ public class SyncDriver implements Runnable{
 				}
 				if (newDevices.size() > 0) {
 					devices.addAll(newDevices);
+					globalTracer.info("LOCATE-NEW: Added " + newDevices.size() + " new devices. Total devices now=" + devices.size());
+				} else {
+					globalTracer.debug("LOCATE-NEW: No new devices found. Total unchanged=" + devices.size());
 				}
-				Monitor.getInstance().setDetectedDeviceCnt(this.devices.size() + this.failedDevices.size());
-				Monitor.getInstance().setFailedDeviceCnt(this.failedDevices.size());
+				refreshMonitorDeviceCounts();
 				if (latestDeviceCount > ConfLoader.getInstance().getDeviceCountLimit()) {
 					globalTracer.error("Device count exceeded the specified limit of " + ConfLoader.getInstance().getDeviceCountLimit() + ". Please renew your license.");
 					deviceLocator.shutdown();
@@ -589,11 +605,42 @@ public class SyncDriver implements Runnable{
 					}
 				}
 			}
-			Monitor.getInstance().setDetectedDeviceCnt(this.devices.size() + this.failedDevices.size());
-			Monitor.getInstance().setFailedDeviceCnt(this.failedDevices.size());
+			refreshMonitorDeviceCounts();
 		} catch (Exception e) {
 			globalTracer.error("Failed device scheduler failed with exception : ", e);
 		}
+	}
+
+	private void refreshMonitorDeviceCounts() {
+		long detectedCnt = this.devices.size() + this.failedDevices.size();
+		long failedCnt = this.failedDevices.size();
+		long registeredCnt = 0;
+		long initializedCnt = 0;
+
+		Set<Device> allKnownDevices = new HashSet<Device>(this.devices);
+		allKnownDevices.addAll(this.failedDevices);
+		for (Device device : allKnownDevices) {
+			if (device.getStatus() != DeviceStatus.UNREGISTERED) {
+				registeredCnt += 1;
+			}
+
+			boolean initialized = false;
+			for (int dstIndex : device.getAllDstIndexes()) {
+				if (device.getConsolidatorMetadataMgr(dstIndex).getInitializationStatus() == 1) {
+					initialized = true;
+					break;
+				}
+			}
+			if (initialized) {
+				initializedCnt += 1;
+			}
+		}
+
+		globalTracer.debug("MONITOR-COUNTS: detected=" + detectedCnt + " registered=" + registeredCnt + " initialized=" + initializedCnt + " failed=" + failedCnt + " (devices=" + this.devices.size() + " failedDevices=" + this.failedDevices.size() + ")");
+		Monitor.getInstance().setDetectedDeviceCnt(detectedCnt);
+		Monitor.getInstance().setFailedDeviceCnt(failedCnt);
+		Monitor.getInstance().setRegisteredDeviceCnt(registeredCnt);
+		Monitor.getInstance().setInitializedDeviceCnt(initializedCnt);
 	}
 
 	private final void doSyncContinuous() {
@@ -787,23 +834,30 @@ public class SyncDriver implements Runnable{
 
 
 	private final Void locateDevicesAndStartScheduler() throws SyncLiteException {
+		globalTracer.info("STARTUP: locateDevicesAndStartScheduler() invoked. Beginning device reload.");
+		globalTracer.debug("STARTUP: deviceUploadRoot=" + ConfLoader.getInstance().getDeviceUploadRoot() + " deviceDataRoot=" + ConfLoader.getInstance().getDeviceDataRoot());
 		locator.tryReloadDevices(devices);
+		globalTracer.info("STARTUP: tryReloadDevices() complete. Total devices loaded=" + devices.size() + " failedDevices=" + failedDevices.size());
+		refreshMonitorDeviceCounts();
 
 		//Add devices to task queue 
 		if ((ConfLoader.getInstance().getDeviceSchedulerType() == DeviceSchedulerType.POLLING) || (ConfLoader.getInstance().getDeviceSchedulerType() == DeviceSchedulerType.EVENT_BASED)) {
+			int queued = 0;
 			for (Device device : devices) {
-				globalTracer.debug("Device " + device.getDeviceUUID() + " status : " + device.getStatus());
+				globalTracer.debug("STARTUP: device " + device.getDeviceUUID() + " (" + device.getDeviceName() + ") status=" + device.getStatus());
 				if ((device.getStatus() == DeviceStatus.SYNCING) ||
 						(device.getStatus() == DeviceStatus.SYNCING_FAILED) ||
 						(device.getStatus() == DeviceStatus.REGISTERED))
 				{
 					try {
 						addDeviceTask(device);
+						queued++;
 					} catch (InterruptedException e) {
 						Thread.currentThread().interrupt();
 					}
 				} 
-			}			
+			}
+			globalTracer.info("STARTUP: Queued " + queued + " devices for immediate work out of " + devices.size() + " total.");
 		}
 
 		//registerDevices();

--- a/root/core/src/main/java/com/synclite/consolidator/device/Device.java
+++ b/root/core/src/main/java/com/synclite/consolidator/device/Device.java
@@ -892,6 +892,8 @@ public class Device {
 	}
 
 	public static void remove(Device dev) {
+		devices.remove(dev.getDeviceUploadRoot());
+		devices.remove(dev.getDeviceUploadRoot().getFileName());
 		devices.remove(dev.getDeviceDataRoot());
 		nameToDeviceMap.remove(dev.getDeviceName());
 		idToDeviceMap.remove(dev.getDeviceUUID());
@@ -902,19 +904,27 @@ public class Device {
 		if (root == null) {
 			return null;
 		}
-		return devices.computeIfAbsent(upload.getFileName(), s -> {
-			try {
-				Device dev = new Device(root, upload);
-				nameToDeviceMap.put(dev.getDeviceName(), dev);
-				idToDeviceMap.put(dev.getDeviceUUID(), dev);
-				return dev;
-			} catch (SyncLiteException e) {
-				throw new RuntimeException(e);
-			}
-		});
+		Device cached = devices.get(upload);
+		if (cached != null) {
+			return cached;
+		}
+
+		Device dev = new Device(root, upload);
+		Device existing = devices.putIfAbsent(upload, dev);
+		if (existing != null) {
+			return existing;
+		}
+
+		nameToDeviceMap.put(dev.getDeviceName(), dev);
+		idToDeviceMap.put(dev.getDeviceUUID(), dev);
+		return dev;
 	}
 
 	public static Device findInstance(Path upload) {
+		Device dev = devices.get(upload);
+		if (dev != null) {
+			return dev;
+		}
 		return devices.get(upload.getFileName());
 	}
 

--- a/root/core/src/main/java/com/synclite/consolidator/device/DeviceLocator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/device/DeviceLocator.java
@@ -70,19 +70,34 @@ public class DeviceLocator {
 	
 	private void buildDevices(List<Path> deviceUploadRoots, Set<Device> devices) throws SyncLiteStageException {
 		Path baseUploadRoot = ConfLoader.getInstance().getDeviceUploadRoot();
-		for (Path deviceUploadRoot : deviceUploadRoots) {			
+		tracer.debug("DEVICE-BUILD: Building devices from " + deviceUploadRoots.size() + " upload roots, current set size=" + devices.size() + ", baseUploadRoot=" + baseUploadRoot);
+		int attempted = 0, succeeded = 0, skipped = 0;
+		for (Path deviceUploadRoot : deviceUploadRoots) {
+			attempted++;
 			Path deviceRoot = Path.of(root.toString(), baseUploadRoot.relativize(deviceUploadRoot).toString());
+			tracer.debug("DEVICE-BUILD: [" + attempted + "] deviceUploadRoot='" + deviceUploadRoot + "' -> deviceRoot='" + deviceRoot + "'");
 			Device device = locateDeviceAtPath(deviceRoot, deviceUploadRoot);
 			if (device != null) {
-				devices.add(device);
-				Monitor.getInstance().setDetectedDeviceCnt(devices.size());
+				boolean added = devices.add(device);
+				if (added) {
+					succeeded++;
+					Monitor.getInstance().setDetectedDeviceCnt(devices.size());
+					tracer.debug("DEVICE-BUILD: [" + attempted + "] device ADDED: " + device.getDeviceUUID() + " status=" + device.getStatus());
+				} else {
+					skipped++;
+					tracer.debug("DEVICE-BUILD: [" + attempted + "] device ALREADY IN SET (skipped): " + device.getDeviceUUID());
+				}
 
 				if (devices.size() > ConfLoader.getInstance().getDeviceCountLimit()) {
 					tracer.error("Device count exceeded the specified limit of " + ConfLoader.getInstance().getDeviceCountLimit() + ". Please renew your license.");
 					break;
 				}
+			} else {
+				skipped++;
+				tracer.debug("DEVICE-BUILD: [" + attempted + "] locateDeviceAtPath returned null for uploadRoot='" + deviceUploadRoot + "'");
 			}
-		}   	
+		}
+		tracer.debug("DEVICE-BUILD: Done. attempted=" + attempted + " added=" + succeeded + " skipped/null=" + skipped + " total set size=" + devices.size());
 	}
 
 	public final Set<Device> listDevices(Path startFrom) throws SyncLiteException {
@@ -93,33 +108,45 @@ public class DeviceLocator {
 	}    
 
 	public final void tryReloadDevices(Set<Device> devices) throws SyncLiteException {
-		
-		List<Path> deviceUploadRoots = Monitor.getInstance().getDeviceUploadRootsFromStats();
-		buildDevices(deviceUploadRoots, devices);       	
+		tracer.debug("DEVICE-RELOAD: Starting tryReloadDevices. Current device set size=" + devices.size());
 
-		//Load devices from FS now as FS may have newly added devices.
-		deviceUploadRoots = getDeviceUploadRootsFromStage(upload);
+		//Load devices from stage first. This avoids startup stalls if stats DB is busy or slow.
+		List<Path> deviceUploadRoots = getDeviceUploadRootsFromStage(upload);
+		tracer.debug("DEVICE-RELOAD: Stage scan returned " + deviceUploadRoots.size() + " upload roots (upload=" + upload + ")");
 		buildDevices(deviceUploadRoots, devices);
+		tracer.debug("DEVICE-RELOAD: After stage-based reload, device set size=" + devices.size());
+
+		//Use stats-based reload only as a best-effort fallback if stage scan did not yield devices.
+		if (devices.isEmpty()) {
+			try {
+				deviceUploadRoots = Monitor.getInstance().getDeviceUploadRootsFromStats();
+				tracer.debug("DEVICE-RELOAD: Stats returned " + deviceUploadRoots.size() + " upload roots for reload");
+				buildDevices(deviceUploadRoots, devices);
+				tracer.debug("DEVICE-RELOAD: After stats-based fallback reload, device set size=" + devices.size());
+			} catch (RuntimeException e) {
+				tracer.error("DEVICE-RELOAD: Stats-based fallback reload failed, continuing with stage-discovered devices only", e);
+			}
+		}
 	}    
 
 	public Device locateDeviceAtPath(Path deviceRoot, Path deviceUploadRoot) throws SyncLiteStageException {
+		tracer.debug("DEVICE-LOCATE: Checking deviceRoot='" + deviceRoot + "' deviceUploadRoot='" + deviceUploadRoot + "'");
 		if (! deviceStageManager.containerExists(deviceUploadRoot,SyncLiteObjectType.DATA_CONTAINER)) {
 			//If upload root does not exist then ignore 
+			tracer.debug("DEVICE-LOCATE: SKIP — upload container does not exist: " + deviceUploadRoot);
 			return null;
 		}
 		DeviceIdentifier deviceIdentifier = Device.validateDeviceDataRoot(deviceRoot);
 		Device device = null;
 		if (deviceIdentifier != null) {
-			//Don't need to check for existence again
-			/*if (!deviceStageManager.containerExists(deviceUploadRoot)) {
-				return null;
-			}*/
+			tracer.debug("DEVICE-LOCATE: Valid device identifier found: " + deviceIdentifier + " at " + deviceRoot);
 			try {
 				if (ConfLoader.getInstance().isAllowedDevice(deviceIdentifier)) {
 					if (!Files.exists(deviceRoot)) {
 						//create directory
 						try {
 							Files.createDirectories(deviceRoot);
+							tracer.debug("DEVICE-LOCATE: Created missing deviceRoot directory: " + deviceRoot);
 						} catch (IOException e) {
 							throw new SyncLiteException("Failed to create directory " + deviceRoot + " inside " + root, e);
 						}
@@ -127,15 +154,20 @@ public class DeviceLocator {
 
 					device = Device.getInstance(deviceRoot, deviceUploadRoot);
 					if (device.getStatus() == DeviceStatus.REMOVED) {
+						tracer.debug("DEVICE-LOCATE: Device " + device.getDeviceUUID() + " is REMOVED, re-creating instance");
 						Device.remove(device);
 						device = Device.getInstance(deviceRoot, deviceUploadRoot);
 					}
 					allDeviceParents.add(device.getDeviceUploadRoot().getParent());
+					tracer.debug("DEVICE-LOCATE: SUCCESS — device=" + device.getDeviceUUID() + " name=" + device.getDeviceName() + " status=" + device.getStatus());
+				} else {
+					tracer.debug("DEVICE-LOCATE: SKIP — device is NOT allowed by filter: " + deviceIdentifier);
 				}
-			} catch(SyncLiteException e) {
-				//Ignore the device with invalid root
-				//Log somewhere
+			} catch(SyncLiteException | RuntimeException e) {
+				tracer.error("Failed to locate device at path : " + deviceRoot + ", skipping this device", e);
 			}            
+		} else {
+			tracer.debug("DEVICE-LOCATE: SKIP — validateDeviceDataRoot returned null for: " + deviceRoot);
 		}
 		return device;
 	}

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java
@@ -63,27 +63,64 @@ public class DeviceLogCleaner {
 			return;
 		}
 		if (SyncLiteLoggerInfo.isTransactionalDeviceType(device.getDeviceType())) {
-			markAndcleanUpTxnLogsUpto(device.getLastConsolidatedLogSegmentSequenceNumber());
+			markAndcleanUpTxnLogsUpto(lastConsolidatedLogNum);
 		} else {
-			markAndCleanUpTelemetryLogsUpto(device.getLastConsolidatedLogSegmentSequenceNumber());
+			markAndCleanUpTelemetryLogsUpto(lastConsolidatedLogNum);
 		}
-		this.cleanedUpto = lastConsolidatedLogNum;
 	}
 	
 	private void markAndcleanUpTxnLogsUpto(long appliedLogSegmentSeqNum) throws SyncLiteException {
 		CDCLogSegment seg = device.getCDCLogSegment(appliedLogSegmentSeqNum);
-		cleanUpTxnDeviceLogs(appliedLogSegmentSeqNum - 1);
 		if (seg != null) {
 			seg.markApplied();
-		}		
+		}
+		bestEffortCleanUpTxnDeviceLogsUpto(appliedLogSegmentSeqNum - 1);
 	}
 
 	private void markAndCleanUpTelemetryLogsUpto(long appliedLogSegmentSeqNum) throws SyncLiteException {		
 		EventLogSegment seg = device.getEventLogSegment(appliedLogSegmentSeqNum);
-		cleanUpTelemetryDeviceLogs(appliedLogSegmentSeqNum - 1);
 		if (seg != null) {
 			seg.markApplied();
 		}
+		bestEffortCleanUpTelemetryDeviceLogsUpto(appliedLogSegmentSeqNum - 1);
+	}
+
+	private void bestEffortCleanUpTxnDeviceLogsUpto(long targetSeqNum) {
+		if (targetSeqNum < 0) {
+			return;
+		}
+
+		long nextContiguousCleaned = this.cleanedUpto;
+		for (long seqNum = this.cleanedUpto + 1; seqNum <= targetSeqNum; ++seqNum) {
+			try {
+				cleanUpTxnDeviceLogs(seqNum);
+				if (seqNum == (nextContiguousCleaned + 1)) {
+					nextContiguousCleaned = seqNum;
+				}
+			} catch (Exception e) {
+				device.tracer.warn("Cleanup failed for transactional log segment : " + seqNum + ", will retry in next cleanup cycle", e);
+			}
+		}
+		this.cleanedUpto = nextContiguousCleaned;
+	}
+
+	private void bestEffortCleanUpTelemetryDeviceLogsUpto(long targetSeqNum) {
+		if (targetSeqNum < 0) {
+			return;
+		}
+
+		long nextContiguousCleaned = this.cleanedUpto;
+		for (long seqNum = this.cleanedUpto + 1; seqNum <= targetSeqNum; ++seqNum) {
+			try {
+				cleanUpTelemetryDeviceLogs(seqNum);
+				if (seqNum == (nextContiguousCleaned + 1)) {
+					nextContiguousCleaned = seqNum;
+				}
+			} catch (Exception e) {
+				device.tracer.warn("Cleanup failed for telemetry log segment : " + seqNum + ", will retry in next cleanup cycle", e);
+			}
+		}
+		this.cleanedUpto = nextContiguousCleaned;
 	}
 
 	private void cleanUpTxnDeviceLogs(long logSegmentSeqNumber) throws SyncLiteException {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
@@ -68,9 +68,18 @@ public class DeviceStatsCollector {
 		this.consolidatorControlPropMgr = device.getConsolidatorMetadataMgr(this.dstIndex);
 	}
 
+	private void configureSqliteConnection(Connection conn) throws SQLException {
+		try (Statement pragmaStmt = conn.createStatement()) {
+			pragmaStmt.execute("PRAGMA busy_timeout = 5000");
+			pragmaStmt.execute("PRAGMA journal_mode = WAL");
+			pragmaStmt.execute("PRAGMA synchronous = NORMAL");
+		}
+	}
+
 	private void initStatsFile() throws SyncLiteException {
 		String url = "jdbc:sqlite:" + this.statsFilePath;
 		try (Connection statsFileConn = DriverManager.getConnection(url)) {
+			configureSqliteConnection(statsFileConn);
 			try (Statement stmt = statsFileConn.createStatement()) {
 				stmt.execute(createCheckpointTableSql);
 				try (ResultSet rs = stmt.executeQuery(selectCheckpointTableSql.replace("$", this.dstAlias))) {
@@ -117,6 +126,7 @@ public class DeviceStatsCollector {
 				PreparedStatement updateLogSegmentCheckpointTablePstmt = statsFileConn.prepareStatement(updateLogSegmentCheckpointTableSql);
 				Statement statsStmt = statsFileConn.createStatement())
 		{
+			configureSqliteConnection(statsFileConn);
 			updateLogSegmentCheckpointTablePstmt.setLong(1, logSegmentSeqNumber);
 			updateLogSegmentCheckpointTablePstmt.setLong(2, operCount);
 			updateLogSegmentCheckpointTablePstmt.setLong(3, txnCount);
@@ -145,6 +155,7 @@ public class DeviceStatsCollector {
 				PreparedStatement updateCDCLogSegmentCheckpointTablePstmt = statsFileConn.prepareStatement(updateLogSegmentCheckpointTableSql);
 				Statement statsStmt = statsFileConn.createStatement()
 				) {			
+			configureSqliteConnection(statsFileConn);
 			statsFileConn.setAutoCommit(false);
 			long totalOperCount = 0;
 			boolean hasInsertBatch = false;
@@ -251,6 +262,7 @@ public class DeviceStatsCollector {
 			updateCDCLogSegmentCheckpointTablePstmt.setString(5, this.dstAlias);
 			updateCDCLogSegmentCheckpointTablePstmt.execute();
 			statsFileConn.commit();
+			statsFileConn.setAutoCommit(true);
 			device.incrTotalProcessedLogSegmentCount(1);
 			device.incrTotalProcessedOperCount(totalOperCount);
 			device.incrTotalProcessedTxnCount(txnCount);
@@ -277,6 +289,7 @@ public class DeviceStatsCollector {
 				Statement stmt = statsFileConn.createStatement()
 				) {
 
+			configureSqliteConnection(statsFileConn);
 			statsFileConn.setAutoCommit(false);
 			boolean deleteBatchIsFilled = false;
 			boolean insertBatchIsFilled = false;
@@ -323,6 +336,7 @@ public class DeviceStatsCollector {
 			updateSql = updateSql.replace("$4", this.dstAlias);
 			stmt.execute(updateSql);
 			statsFileConn.commit();
+			statsFileConn.setAutoCommit(true);
 			device.incrTotalProcessedOperCount(totalInitializationRowCount);
 			device.incrTotalProcessedTxnCount(consolidatorControlPropMgr.getInitializedTables().entrySet().size());
 			device.incrTotalProcessedLogSize(totalInitializationSnapshotSize);
@@ -343,6 +357,7 @@ public class DeviceStatsCollector {
 		try (Connection statsFileConn = DriverManager.getConnection(url); 
 				Statement stmt = statsFileConn.createStatement()
 				) {			
+			configureSqliteConnection(statsFileConn);
 			String updateSql = updateInitializationStatsCheckpointTableSql.replace("$1", String.valueOf(operCount));
 			updateSql = updateSql.replace("$2", String.valueOf(txnCount));
 			updateSql = updateSql.replace("$3", String.valueOf(size));
@@ -361,12 +376,14 @@ public class DeviceStatsCollector {
 	public final void resetTableStats() throws SyncLiteException {
 		String url = "jdbc:sqlite:" + this.statsFilePath;
 		try (Connection statsFileConn = DriverManager.getConnection(url)) {
+			configureSqliteConnection(statsFileConn);
 			statsFileConn.setAutoCommit(false);
 			try (Statement stmt = statsFileConn.createStatement()) {
 				stmt.execute(deleteAllStatsTableSql.replace("$", this.dstAlias));
 				stmt.execute(resetInitilizationStatsCollectedSql.replace("$", this.dstAlias));
 			}
 			statsFileConn.commit();
+			statsFileConn.setAutoCommit(true);
 		} catch (SQLException e) {
 			throw new SyncLiteException("Failed to delete table stats in stats file : " + statsFilePath, e);
 		}

--- a/root/core/src/main/java/com/synclite/consolidator/watchdog/Monitor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/watchdog/Monitor.java
@@ -264,6 +264,9 @@ public class Monitor {
 				statsConn = DriverManager.getConnection(url);
 
 				try (Statement stmt = statsConn.createStatement()) {
+					stmt.execute("PRAGMA busy_timeout = 5000");
+					stmt.execute("PRAGMA journal_mode = WAL");
+					stmt.execute("PRAGMA synchronous = NORMAL");
 					stmt.execute(createDashboardTableSql);
 					try (ResultSet rs = stmt.executeQuery(selectDashboardTableSql)) {
 						if (!rs.next()) {
@@ -322,6 +325,7 @@ public class Monitor {
 
 		@Override
 		protected void dump() {
+			boolean autoCommitDisabled = false;
 			try {
 				//screenDumper.dump();
 				long currentTime = System.currentTimeMillis();
@@ -332,6 +336,7 @@ public class Monitor {
 					return;
 				}				
 				statsConn.setAutoCommit(false);
+				autoCommitDisabled = true;
 				updateDashboardPstmt.setLong(1, detectedDeviceCnt.get());
 				updateDashboardPstmt.setLong(2, registeredDeviceCnt.get());
 				updateDashboardPstmt.setLong(3, initializedDeviceCnt.get());
@@ -376,10 +381,23 @@ public class Monitor {
 				}
 				statsConn.commit();
 				statsConn.setAutoCommit(true);
+				autoCommitDisabled = false;
 				lastStatFlushTime = currentTime;
 				//TODO keep doing vacuum on statistics file every periodically. 
 
 			} catch (SQLException e) {
+				if (autoCommitDisabled) {
+					try {
+						statsConn.rollback();
+					} catch (SQLException rollbackException) {
+						tracer.error("SyncLite statistics dumper rollback failed with exception : ", rollbackException);
+					}
+					try {
+						statsConn.setAutoCommit(true);
+					} catch (SQLException resetException) {
+						tracer.error("SyncLite statistics dumper failed to reset autocommit after error : ", resetException);
+					}
+				}
 				tracer.error("SyncLite statistics dumper failed with exception : ", e);
 			}
 
@@ -570,8 +588,18 @@ public class Monitor {
 		this.lastStatChangeTime = System.currentTimeMillis();
 	}
 
+	public void setRegisteredDeviceCnt(long cnt) {
+		this.registeredDeviceCnt.set(Math.max(0, cnt));
+		this.lastStatChangeTime = System.currentTimeMillis();
+	}
+
 	public void incrInitializedDeviceCnt(long cnt) {
 		this.initializedDeviceCnt.addAndGet(cnt);
+		this.lastStatChangeTime = System.currentTimeMillis();
+	}
+
+	public void setInitializedDeviceCnt(long cnt) {
+		this.initializedDeviceCnt.set(Math.max(0, cnt));
 		this.lastStatChangeTime = System.currentTimeMillis();
 	}
 
@@ -609,18 +637,48 @@ public class Monitor {
 
 	public final List<Path> getDeviceUploadRootsFromStats() {    		
 		Path statsFilePath = Path.of(ConfLoader.getInstance().getDeviceDataRoot().toString(), "synclite_consolidator_statistics.db");
+		tracer.debug("DEVICE-RELOAD-STATS: Looking for stats file at : " + statsFilePath);
 		if (!Files.exists(statsFilePath)) {
+			tracer.debug("DEVICE-RELOAD-STATS: Stats file not found, returning empty list");
 			return Collections.emptyList();
 		}
 		List<Path> deviceUploadRoots = new ArrayList<Path>();
+		Path deviceDataRoot = ConfLoader.getInstance().getDeviceDataRoot();
+		Path deviceUploadRoot = ConfLoader.getInstance().getDeviceUploadRoot();
+		tracer.debug("DEVICE-RELOAD-STATS: deviceDataRoot=" + deviceDataRoot + " deviceUploadRoot=" + deviceUploadRoot);
 		String url = "jdbc:sqlite:" + statsFilePath;
 		try (Connection conn = DriverManager.getConnection(url)) {
 			try (Statement stmt = conn.createStatement()) {
+				stmt.execute("PRAGMA busy_timeout = 5000");
+				stmt.setQueryTimeout(5);
 				try (ResultSet rs = stmt.executeQuery("SELECT path FROM device_status")) {
+					int rowCount = 0;
+					int sampledRows = 0;
 					while (rs.next()) {
-						Path deviceUploadPath = Path.of(ConfLoader.getInstance().getDeviceUploadRoot().toString(), Path.of(rs.getString(1)).getFileName().toString());
+						rowCount++;
+						String rawPath = rs.getString(1);
+						Path storedDevicePath;
+						try {
+							storedDevicePath = Path.of(rawPath);
+						} catch (RuntimeException invalidPathException) {
+							tracer.error("DEVICE-RELOAD-STATS: Invalid path in device_status row=" + rowCount + " path='" + rawPath + "', skipping row", invalidPathException);
+							continue;
+						}
+						Path relativeDevicePath;
+						try {
+							relativeDevicePath = deviceDataRoot.relativize(storedDevicePath);
+						} catch (IllegalArgumentException e) {
+							tracer.debug("DEVICE-RELOAD-STATS: Cannot relativize stored path '" + rawPath + "' against deviceDataRoot '" + deviceDataRoot + "', falling back to getFileName()");
+							relativeDevicePath = storedDevicePath.getFileName();
+						}
+						Path deviceUploadPath = deviceUploadRoot.resolve(relativeDevicePath);
+						if (rowCount <= 5 || (rowCount % 25) == 0) {
+							sampledRows++;
+							tracer.debug("DEVICE-RELOAD-STATS: row=" + rowCount + " storedPath='" + rawPath + "' relativePath='" + relativeDevicePath + "' resolvedUploadPath='" + deviceUploadPath + "'");
+						}
 						deviceUploadRoots.add(deviceUploadPath);
 					}
+					tracer.debug("DEVICE-RELOAD-STATS: Total device_status rows read=" + rowCount + ", upload paths reconstructed=" + deviceUploadRoots.size() + ", sampledRowLogs=" + sampledRows);
 				}
 			}    			
 		} catch (SQLException e) {

--- a/root/core/src/main/resources/log4j.properties
+++ b/root/core/src/main/resources/log4j.properties
@@ -1,14 +1,9 @@
 # Root logger option
-log4j.rootLogger=DEBUG, global, device
+# Keep default at INFO for lower runtime overhead; enable DEBUG only for short diagnostics.
+log4j.rootLogger=INFO, global
  
 # RollingFileAppender 
 log4j.appender.global=org.apache.log4j.RollingFileAppender 
 log4j.appender.global.File=synclite_consolidator.trace 
 log4j.appender.global.layout=org.apache.log4j.PatternLayout 
-log4j.appender.global.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %l - %m%n
-
-
-log4j.appender.device=org.apache.log4j.RollingFileAppender 
-log4j.appender.device.File=synclite_consolidator.trace 
-log4j.appender.device.layout=org.apache.log4j.PatternLayout 
-log4j.appender.device.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %l - %m%n
+log4j.appender.global.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p [%c{1}] - %m%n

--- a/root/web/pom.xml
+++ b/root/web/pom.xml
@@ -142,28 +142,18 @@
 		    <version>20250107</version>
 		</dependency>
 
-		<!-- Log4j 2.x with 1.x API bridge for backward compatibility -->
+		<!-- reload4j: CVE-clean drop-in replacement for log4j 1.x (no bridge chain overhead) -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-1.2-api</artifactId>
-			<version>2.24.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>2.24.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>2.24.3</version>
+			<groupId>ch.qos.reload4j</groupId>
+			<artifactId>reload4j</artifactId>
+			<version>1.2.25</version>
 		</dependency>
 
-		<!-- SLF4J bridge to route SLF4J calls through Log4j 2.x -->
+		<!-- SLF4J bridge to route SLF4J calls through reload4j -->
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j2-impl</artifactId>
-			<version>2.24.3</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-reload4j</artifactId>
+			<version>2.0.17</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz -->


### PR DESCRIPTION
# PR: Startup Stability, Logging Overhead Reduction, and Build Pipeline Cleanup

## Summary
This PR improves consolidator startup stability and observability by addressing SQLite contention handling, reducing logging overhead, tightening device reload/count behavior, and simplifying build-time packaging/report generation.

## Problem Statement
During startup/reload at scale, we observed:
- Intermittent SQLite lock contention symptoms in stats paths.
- Thread stalls dominated by synchronous logging overhead from very high debug volume.
- Counter timing mismatch where detected devices could lag while registered/initialized advanced.
- Slow build flow due to always-on third-party license retrieval.
- Maven install instability when assembly output directory was treated as an attachable artifact.

## Scope of Changes

### 1) SQLite stats hardening
Files:
- root/core/src/main/java/com/synclite/consolidator/watchdog/Monitor.java
- root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java

Changes:
- Applied SQLite pragmas on relevant connections:
  - `PRAGMA busy_timeout = 5000`
  - `PRAGMA journal_mode = WAL`
  - `PRAGMA synchronous = NORMAL`
- Added safer transaction cleanup in monitor stats dumper:
  - rollback on failure when autocommit had been disabled
  - explicit autocommit reset after rollback
- Added explicit autocommit reset to true after commits in stats collector write paths.
- Added query timeout for stats-read path where device upload roots are reconstructed.

Impact:
- Better resilience under lock pressure.
- Lower chance of lingering dirty transaction state on error.

### 2) Device reload/order and count consistency
Files:
- root/core/src/main/java/com/synclite/consolidator/device/DeviceLocator.java
- root/core/src/main/java/com/synclite/consolidator/SyncDriver.java
- root/core/src/main/java/com/synclite/consolidator/device/Device.java

Changes:
- Device reload now prefers stage scan first; stats-based reload is fallback when stage returns empty.
- Added startup/reload instrumentation logs for detector, locator, and queueing behavior.
- Added `refreshMonitorDeviceCounts()` in `SyncDriver` to compute/update detected/failed/registered/initialized together from current state.
- Hooked count refresh into relevant scheduler/reload paths.
- Updated `DeviceLocator.buildDevices()` to set detected count incrementally as devices are added.
- Fixed `Device` instance map behavior:
  - normalize cache lookup by upload path
  - safer put-if-absent flow
  - improved remove/find behavior for upload-root keyed instances.

Impact:
- Startup path less prone to stalls from stats DB dependence.
- Device counters converge more predictably and are refreshed consistently.
- Better visibility when debugging detector and locator behavior.

### 3) Logging overhead reduction
Files:
- root/core/src/main/resources/log4j.properties
- root/core/src/main/java/com/synclite/consolidator/watchdog/Monitor.java
- root/core/src/main/java/com/synclite/consolidator/device/DeviceLocator.java
- root/core/src/main/java/com/synclite/consolidator/SyncDriver.java

Changes:
- Default root level moved to INFO.
- Removed duplicate file appender writing to same trace target.
- Simplified pattern from caller-location-heavy formatting to class-based context.
- Reduced row-level stats logging by sampling in stats reload flow.
- Added structured startup/reload debug statements for targeted diagnostics.

Impact:
- Lower synchronous log I/O pressure.
- Cleaner operational logs with less startup noise at default level.

### 4) Log framework dependency stack simplification
Files:
- root/core/pom.xml
- root/web/pom.xml

Changes:
- Replaced Log4j2 bridge stack with reload4j + SLF4J reload4j binding:
  - removed log4j-1.2-api/log4j-api/log4j-core/log4j-slf4j2-impl
  - added `ch.qos.reload4j:reload4j:1.2.25`
  - added `org.slf4j:slf4j-reload4j:2.0.17`

Impact:
- Simpler logging chain for log4j-1.x API usage.
- Reduced bridge/adapter complexity.

### 5) Build pipeline reliability + speed
Files:
- root/core/pom.xml

Changes:
- Prevented assembly directory from being attached as install artifact:
  - `<attach>false</attach>` in maven-assembly-plugin configuration.
- Moved `license-maven-plugin` execution into opt-in profile `license-report`.

Impact:
- `mvn install` no longer fails due to directory attachment issue.
- Normal build avoids expensive license retrieval calls.

## Additional behavior fix
File:
- root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java

Changes:
- Switched cleanup to best-effort contiguous progression with warning logs on failures.
- Keeps `cleanedUpto` moving only across contiguous successfully cleaned segments.

Impact:
- More robust cleanup behavior under transient failures.

## Validation Performed
Build/compile checks run:
- `mvn -pl core -DskipTests compile`
- `mvn -Drevision=oss clean install -DskipTests`
- `mvn -Drevision=oss -DskipTests package`

Runtime inspection:
- Consolidator trace shows startup completion and stable monitor counts over cycles.
- No recent `SQLITE_BUSY`/exception pattern in inspected tail during latest run.

## Risk Assessment
- Moderate: touches startup/reload, monitor counters, and logging dependencies.
- Low/Moderate: behavior is backward-compatible at API level; main risk is operational differences in logs and startup sequence timing.

## Rollback Plan
If issues arise:
1. Revert `root/core/pom.xml` and `root/web/pom.xml` dependency changes.
2. Revert `root/core/src/main/resources/log4j.properties` to previous logging config.
3. Revert startup/count changes in:
   - `SyncDriver.java`
   - `DeviceLocator.java`
   - `Monitor.java`
   - `Device.java`
   - `DeviceStatsCollector.java`
   - `DeviceLogCleaner.java`

