### PR TITLE
Fix argument count value based on current transaction file.

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/log/CommandLogSegment.java
+++ b/root/core/src/main/java/com/synclite/consolidator/log/CommandLogSegment.java
@@ -143,8 +143,26 @@ public class CommandLogSegment extends LogSegment {
 
 						try {
 							txnDBHandle = new DB(txnFilePath);
-							txnLogReaderStmt = txnDBHandle.prepare(txnLogSegmentReaderSql);
-							this.hasNextLog = txnLogReaderStmt.stepQuery();                    
+							// Dynamically determine arg columns in txn file
+							List<String> argColumns = new ArrayList<>();
+							try (java.sql.Connection pragmaConn = java.sql.DriverManager.getConnection("jdbc:sqlite:" + txnFilePath.toString());
+								 java.sql.Statement pragmaStmt = pragmaConn.createStatement();
+								 java.sql.ResultSet pragmaRS = pragmaStmt.executeQuery("PRAGMA table_info('commandlog')")) {
+								int colIdx = 0;
+								while (pragmaRS.next()) {
+									++colIdx;
+									if (colIdx > 4) { // skip change_number, commit_id, sql, arg_cnt
+										argColumns.add(pragmaRS.getString("name"));
+									}
+								}
+							}
+							StringBuilder selectSql = new StringBuilder("SELECT change_number, commit_id, sql, arg_cnt");
+							for (String col : argColumns) {
+								selectSql.append(", ").append(col);
+							}
+							selectSql.append(" FROM commandlog ORDER BY change_number");
+							txnLogReaderStmt = txnDBHandle.prepare(selectSql.toString());
+							this.hasNextLog = txnLogReaderStmt.stepQuery();
 							if (this.hasNextLog != 0) {
 								changeNumber = prevMainLogRecord.changeNumber;
 								commitId = prevMainLogRecord.commitId;
@@ -152,8 +170,8 @@ public class CommandLogSegment extends LogSegment {
 								sql = txnLogReaderStmt.getString(2);
 								argCnt = txnLogReaderStmt.getLong(3);
 								args.clear();
-								for (int i = 1; i <= argCnt; i++) {
-									//Bind all arguments
+								//Bind all arguments
+								for (int i = 1; i <= argCnt && i <= argColumns.size(); i++) {
 									args.add(txnLogReaderStmt.getNativeValue(i+3));
 								}
 								if (sql == null) {

--- a/root/core/src/main/java/com/synclite/consolidator/log/EventLogSegment.java
+++ b/root/core/src/main/java/com/synclite/consolidator/log/EventLogSegment.java
@@ -138,9 +138,25 @@ public class EventLogSegment extends LogSegment {
 
 						try {
 							txnDBHandle = DriverManager.getConnection("jdbc:sqlite:" + txnFilePath);
-							txnLogReaderStmt = txnDBHandle.prepareStatement(commandLogSegmentReaderSql);
-							txnLogReaderStmtRS = txnLogReaderStmt.executeQuery();                        
-
+							// Dynamically determine arg columns in txn file
+							List<String> argColumns = new ArrayList<>();
+							try (Statement pragmaStmt = txnDBHandle.createStatement();
+								 ResultSet pragmaRS = pragmaStmt.executeQuery("PRAGMA table_info('commandlog')")) {
+								int colIdx = 0;
+								while (pragmaRS.next()) {
+									++colIdx;
+									if (colIdx > 4) { // skip change_number, commit_id, sql, arg_cnt
+										argColumns.add(pragmaRS.getString("name"));
+									}
+								}
+							}
+							StringBuilder selectSql = new StringBuilder("SELECT change_number, commit_id, sql, arg_cnt");
+							for (String col : argColumns) {
+								selectSql.append(", ").append(col);
+							}
+							selectSql.append(" FROM commandlog ORDER BY change_number");
+							txnLogReaderStmt = txnDBHandle.prepareStatement(selectSql.toString());
+							txnLogReaderStmtRS = txnLogReaderStmt.executeQuery();
 							this.hasNextLog = txnLogReaderStmtRS.next();
 							if (this.hasNextLog == true) {
 								changeNumber = prevMainLogRecord.changeNumber;
@@ -149,8 +165,8 @@ public class EventLogSegment extends LogSegment {
 								sql = txnLogReaderStmtRS.getString("sql");
 								argCnt = txnLogReaderStmtRS.getLong("arg_cnt");
 								args.clear();
-								for (int i = 1; i <= argCnt; i++) {
-									//Bind all arguments
+								//Bind all arguments
+								for (int i = 1; i <= argCnt && i <= argColumns.size(); i++) {
 									args.add(txnLogReaderStmtRS.getObject(i+4));
 								}
 								if (sql == null) {


### PR DESCRIPTION
## Problem

When processing command log segments, the code previously assumed that the schema (number of argument columns) in the main log file and all txn files was identical. If a txn file had a different schema (more or fewer arg columns), this caused out-of-bounds errors or incorrect data binding.

## Root Cause
The SELECT statements and argument binding logic were based on a fixed column count, not adapting to schema drift between main and txn files.

## Fix
The logic to dynamically determine the actual schema (argument columns) of each commandlog table was moved into CommandLogSegment (and its reader). Now, when a txn file is opened, CommandLogSegment uses PRAGMA table_info to discover the real columns and builds the correct SELECT statement for that file.