### PR TITLE
Metadata refactor

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/device/Device.java
+++ b/root/core/src/main/java/com/synclite/consolidator/device/Device.java
@@ -51,6 +51,7 @@ import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.exception.SyncLiteStageException;
 import com.synclite.consolidator.global.ConfLoader;
 import com.synclite.consolidator.global.ConsolidatorMetadataManager;
+import com.synclite.consolidator.global.MetadataRetry;
 import com.synclite.consolidator.global.DevicePatternType;
 import com.synclite.consolidator.global.MetadataManager;
 import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
@@ -913,7 +914,8 @@ public class Device {
 	}
 
 	public void resetInitializedSnapshot(int dstIndex) throws SyncLiteException {    	
-		consolidatorMetadataMgrs.get(dstIndex).resetInitializedSnapshot();
+		MetadataRetry.retry(dstIndex, tracer, "resetInitializedSnapshot",
+				() -> consolidatorMetadataMgrs.get(dstIndex).resetInitializedSnapshot());
 	}
 
 	public static Device getDeviceByName(String deviceName) {
@@ -1295,28 +1297,16 @@ public class Device {
 		}
 		
 		for(int dstIndex : allDstIndexes) {
+			HashMap<String, Object> identity = new HashMap<>();
+			identity.put("database_name", this.dbName);
+			identity.put("device_name", this.deviceName);
+			identity.put("device_type", this.deviceType);
+			identity.put("database_id", this.dbID);
 			try {
-				consolidatorMetadataMgrs.get(dstIndex).upsertProperty("database_name", this.dbName);
+				MetadataRetry.retry(dstIndex, tracer, "seed_consolidator_identity",
+						() -> consolidatorMetadataMgrs.get(dstIndex).upsertProperties(identity));
 			} catch (SQLException e) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_name record in the importer metadata file");
-			}
-
-			try {
-				consolidatorMetadataMgrs.get(dstIndex).upsertProperty("device_name", this.deviceName);
-			} catch (SQLException e) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_name record in the importer metadata file");
-			}
-
-			try {
-				consolidatorMetadataMgrs.get(dstIndex).upsertProperty("device_type", this.deviceType);
-			} catch (SQLException e) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_type record in the importer metadata file");
-			}
-
-			try {
-				consolidatorMetadataMgrs.get(dstIndex).upsertProperty("database_id", this.dbID);
-			} catch (SQLException e) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write database_id record in the importer metadata file");
+				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write identity records in the importer metadata file");
 			}
 		}
 
@@ -1705,7 +1695,8 @@ public class Device {
 
 	private final void reInitialize(int dstIndex) throws SyncLiteException {
 		tracer.info("Marking device for reinitialization for dst : " + dstIndex);
-		this.consolidatorMetadataMgrs.get(dstIndex).resetInitializationStatus();	
+		MetadataRetry.retry(dstIndex, tracer, "resetInitializationStatus",
+				() -> this.consolidatorMetadataMgrs.get(dstIndex).resetInitializationStatus());
 		dataBackupSnapshot();
 		resetDeviceTableStats(dstIndex);
 		tracer.info("Marked device for reinitialization for dst : " + dstIndex);

--- a/root/core/src/main/java/com/synclite/consolidator/global/ConfLoader.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConfLoader.java
@@ -2810,8 +2810,8 @@ public class ConfLoader {
 				}
 				line = reader.readLine();
 			}
-			//Always allow synclite_metadata table
-			this.dstTableFilterMapperRules[dstIndex].put(SyncLiteConsolidatorInfo.getSyncLiteMetadataTableName().toUpperCase(), "true");
+			//Always allow synclite_checkpoint table
+			this.dstTableFilterMapperRules[dstIndex].put(SyncLiteConsolidatorInfo.getSyncLiteCheckpointTableName().toUpperCase(), "true");
 		} catch (IOException e) {
 			throw new SyncLitePropsException("Failed to load configuration file : " + filterMapperRulesFile + " : ", e);
 		} finally {

--- a/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
@@ -62,15 +62,15 @@ public class ConsolidatorMetadataManager extends MetadataManager {
 
     private static final String createDstMetadataTblSql =
             "CREATE TABLE IF NOT EXISTS synclite_consolidator_metadata(" +
-            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, dst_index INTEGER NOT NULL, " +
+            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, " +
             "prop_key VARCHAR(255) NOT NULL, prop_value TEXT, " +
-            "PRIMARY KEY(device_uuid, device_name, dst_index, prop_key))";
+            "PRIMARY KEY(device_uuid, device_name, prop_key))";
 
     private static final String createDstTableMetadataTblSql =
             "CREATE TABLE IF NOT EXISTS synclite_consolidator_table_metadata(" +
-            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, dst_index INTEGER NOT NULL, " +
+            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, " +
             "database_name VARCHAR(255) NOT NULL, table_name VARCHAR(255) NOT NULL, prop_key VARCHAR(255) NOT NULL, prop_value TEXT, " +
-            "PRIMARY KEY(device_uuid, device_name, dst_index, database_name, table_name, prop_key))";
+            "PRIMARY KEY(device_uuid, device_name, database_name, table_name, prop_key))";
 
     protected ConsolidatorMetadataManager(Path metadataFilePath, Device device, int dstIndex) throws SQLException {
         super(metadataFilePath);
@@ -104,14 +104,13 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         // DESTINATION mode: read from destination
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             ensureDstTableMetadataTable(conn);
-            String sql = "SELECT prop_value FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND database_name = ? AND table_name = ? AND prop_key = ?";
+            String sql = "SELECT prop_value FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND database_name = ? AND table_name = ? AND prop_key = ?";
             try (PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
-                stmt.setInt(3, this.dstIndex);
-                stmt.setString(4, srcTable.id.database);
-                stmt.setString(5, srcTable.id.table);
-                stmt.setString(6, key);
+                stmt.setString(3, srcTable.id.database);
+                stmt.setString(4, srcTable.id.table);
+                stmt.setString(5, key);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
                         return rs.getObject(1);
@@ -137,11 +136,11 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstTableMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement stmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ?")) {
+                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ?")) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
-                stmt.setInt(3, this.dstIndex);
                 stmt.execute();
             }
             conn.commit();
@@ -158,14 +157,15 @@ public class ConsolidatorMetadataManager extends MetadataManager {
                 }
             }
         } else {
-            // DESTINATION mode: delete from destination synclite_table_schema
+            // DESTINATION mode: delete create_sql rows from unified table_metadata
             try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
                 conn.setAutoCommit(false);
+                ensureDstTableMetadataTable(conn);
+                seedDstMetadataVersionIfAbsent(conn);
                 try (PreparedStatement stmt = conn.prepareStatement(
-                        "DELETE FROM synclite_table_schema WHERE device_uuid = ? AND device_name = ? AND dst_index = ?")) {
+                        "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = 'create_sql'")) {
                     stmt.setString(1, this.device.getDeviceUUID());
                     stmt.setString(2, this.device.getDeviceName());
-                    stmt.setInt(3, this.dstIndex);
                     stmt.execute();
                 }
                 conn.commit();
@@ -202,25 +202,24 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstTableMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND database_name = ? AND table_name = ? AND prop_key = ?");
+                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND database_name = ? AND table_name = ? AND prop_key = ?");
                  PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_table_metadata(device_uuid, device_name, dst_index, database_name, table_name, prop_key, prop_value) VALUES(?, ?, ?, ?, ?, ?, ?)")) {
+                    "INSERT INTO synclite_consolidator_table_metadata(device_uuid, device_name, database_name, table_name, prop_key, prop_value) VALUES(?, ?, ?, ?, ?, ?)")) {
                 deleteStmt.setString(1, this.device.getDeviceUUID());
                 deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setInt(3, this.dstIndex);
-                deleteStmt.setString(4, srcTable.id.database);
-                deleteStmt.setString(5, srcTable.id.table);
-                deleteStmt.setString(6, key);
+                deleteStmt.setString(3, srcTable.id.database);
+                deleteStmt.setString(4, srcTable.id.table);
+                deleteStmt.setString(5, key);
                 deleteStmt.execute();
 
                 insertStmt.setString(1, this.device.getDeviceUUID());
                 insertStmt.setString(2, this.device.getDeviceName());
-                insertStmt.setInt(3, this.dstIndex);
-                insertStmt.setString(4, srcTable.id.database);
-                insertStmt.setString(5, srcTable.id.table);
-                insertStmt.setString(6, key);
-                insertStmt.setString(7, value == null ? null : value.toString());
+                insertStmt.setString(3, srcTable.id.database);
+                insertStmt.setString(4, srcTable.id.table);
+                insertStmt.setString(5, key);
+                insertStmt.setString(6, value == null ? null : value.toString());
                 insertStmt.execute();
             }
             conn.commit();
@@ -341,6 +340,48 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         }
     }
 
+    private volatile boolean dstVersionSeeded = false;
+
+    /**
+     * Seed the {@code synclite_metadata_version} row inline on the caller's connection.
+     * Must be called on a writer path: the caller's subsequent {@code commit()} makes the
+     * insert durable. Opening a second pool connection here would deadlock against the
+     * caller's open transaction on the same SQLite file (SQLITE_BUSY).
+     */
+    private void seedDstMetadataVersionIfAbsent(Connection conn) throws SQLException {
+        if (dstVersionSeeded) {
+            return;
+        }
+        // The seed targets synclite_consolidator_metadata; ensure that table exists
+        // regardless of which writer path (property vs. table-metadata) reached us first.
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute(createDstMetadataTblSql);
+        }
+        try (PreparedStatement sel = conn.prepareStatement(
+                "SELECT 1 FROM synclite_consolidator_metadata "
+                + "WHERE device_uuid = ? AND device_name = ? AND prop_key = ?")) {
+            sel.setString(1, this.device.getDeviceUUID());
+            sel.setString(2, this.device.getDeviceName());
+            sel.setString(3, SYNCLITE_METADATA_VERSION_KEY);
+            try (ResultSet rs = sel.executeQuery()) {
+                if (rs.next()) {
+                    dstVersionSeeded = true;
+                    return;
+                }
+            }
+        }
+        try (PreparedStatement ins = conn.prepareStatement(
+                "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) "
+                + "VALUES(?, ?, ?, ?)")) {
+            ins.setString(1, this.device.getDeviceUUID());
+            ins.setString(2, this.device.getDeviceName());
+            ins.setString(3, SYNCLITE_METADATA_VERSION_KEY);
+            ins.setString(4, Long.toString(SYNCLITE_METADATA_VERSION));
+            ins.execute();
+        }
+        dstVersionSeeded = true;
+    }
+
     private void ensureDstTableMetadataTable(Connection conn) throws SQLException {
         try (Statement stmt = conn.createStatement()) {
             stmt.execute(createDstTableMetadataTblSql);
@@ -356,23 +397,22 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND prop_key = ?");
+                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?");
                  PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, dst_index, prop_key, prop_value) VALUES(?, ?, ?, ?, ?)")) {
+                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) VALUES(?, ?, ?, ?)")) {
                 for (Map.Entry<String, Object> entry : values.entrySet()) {
                     String val = entry.getValue() == null ? null : entry.getValue().toString();
                     deleteStmt.setString(1, this.device.getDeviceUUID());
                     deleteStmt.setString(2, this.device.getDeviceName());
-                    deleteStmt.setInt(3, this.dstIndex);
-                    deleteStmt.setString(4, entry.getKey());
+                    deleteStmt.setString(3, entry.getKey());
                     deleteStmt.addBatch();
 
                     insertStmt.setString(1, this.device.getDeviceUUID());
                     insertStmt.setString(2, this.device.getDeviceName());
-                    insertStmt.setInt(3, this.dstIndex);
-                    insertStmt.setString(4, entry.getKey());
-                    insertStmt.setString(5, val);
+                    insertStmt.setString(3, entry.getKey());
+                    insertStmt.setString(4, val);
                     insertStmt.addBatch();
                 }
                 deleteStmt.executeBatch();
@@ -393,21 +433,20 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND prop_key = ?");
+                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?");
                  PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, dst_index, prop_key, prop_value) VALUES(?, ?, ?, ?, ?)")) {
+                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) VALUES(?, ?, ?, ?)")) {
                 deleteStmt.setString(1, this.device.getDeviceUUID());
                 deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setInt(3, this.dstIndex);
-                deleteStmt.setString(4, key);
+                deleteStmt.setString(3, key);
                 deleteStmt.execute();
 
                 insertStmt.setString(1, this.device.getDeviceUUID());
                 insertStmt.setString(2, this.device.getDeviceName());
-                insertStmt.setInt(3, this.dstIndex);
-                insertStmt.setString(4, key);
-                insertStmt.setString(5, value == null ? null : value.toString());
+                insertStmt.setString(3, key);
+                insertStmt.setString(4, value == null ? null : value.toString());
                 insertStmt.execute();
             }
             conn.commit();
@@ -425,12 +464,12 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND prop_key = ?")) {
+                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?")) {
                 deleteStmt.setString(1, this.device.getDeviceUUID());
                 deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setInt(3, this.dstIndex);
-                deleteStmt.setString(4, key);
+                deleteStmt.setString(3, key);
                 deleteStmt.execute();
             }
             conn.commit();
@@ -446,12 +485,11 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         }
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             ensureDstMetadataTable(conn);
-            String sql = "SELECT prop_value FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ? AND prop_key = ?";
+            String sql = "SELECT prop_value FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?";
             try (PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
-                stmt.setInt(3, this.dstIndex);
-                stmt.setString(4, key);
+                stmt.setString(3, key);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
                         return rs.getString(1);
@@ -483,11 +521,12 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         } else {
             try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
                 conn.setAutoCommit(false);
+                ensureDstTableMetadataTable(conn);
+                seedDstMetadataVersionIfAbsent(conn);
                 try (PreparedStatement stmt = conn.prepareStatement(
-                        "DELETE FROM synclite_table_schema WHERE device_uuid = ? AND device_name = ? AND dst_index = ?")) {
+                        "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = 'create_sql'")) {
                     stmt.setString(1, this.device.getDeviceUUID());
                     stmt.setString(2, this.device.getDeviceName());
-                    stmt.setInt(3, this.dstIndex);
                     stmt.execute();
                 }
                 conn.commit();
@@ -510,11 +549,11 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             ensureDstTableMetadataTable(conn);
+            seedDstMetadataVersionIfAbsent(conn);
             try (PreparedStatement stmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND dst_index = ?")) {
+                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ?")) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
-                stmt.setInt(3, this.dstIndex);
                 stmt.execute();
             }
             conn.commit();
@@ -670,7 +709,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
             try (Statement stmt = conn.createStatement()) {
-                stmt.execute("CREATE TABLE IF NOT EXISTS synclite_metadata("
+                stmt.execute("CREATE TABLE IF NOT EXISTS synclite_checkpoint("
                         + "synclite_device_id TEXT NOT NULL, "
                         + "synclite_device_name TEXT NOT NULL, "
                         + "synclite_update_timestamp TEXT, "
@@ -682,7 +721,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
                         + "PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))");
             }
             try (PreparedStatement updateStmt = conn.prepareStatement(
-                    "UPDATE synclite_metadata SET initialization_status = 0 WHERE synclite_device_id = ? AND synclite_device_name = ?")) {
+                    "UPDATE synclite_checkpoint SET initialization_status = 0 WHERE synclite_device_id = ? AND synclite_device_name = ?")) {
                 updateStmt.setString(1, this.device.getDeviceUUID());
                 updateStmt.setString(2, this.device.getDeviceName());
                 updateStmt.execute();

--- a/root/core/src/main/java/com/synclite/consolidator/global/MetadataManager.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/MetadataManager.java
@@ -27,6 +27,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MetadataManager {
+	/** Bump when on-disk metadata layout/semantics change in a non-back-compatible way.
+	 *  Stored in the `metadata` table under {@link #SYNCLITE_METADATA_VERSION_KEY} so a
+	 *  future consolidator version can detect an older store and run a migration routine. */
+	public static final long SYNCLITE_METADATA_VERSION = 1L;
+	public static final String SYNCLITE_METADATA_VERSION_KEY = "synclite_metadata_version";
+
 	protected Path metadataFilePath;
 	protected static final ConcurrentHashMap<Path, MetadataManager> metadataMgrs= new ConcurrentHashMap<Path, MetadataManager>();
 
@@ -43,8 +49,20 @@ public class MetadataManager {
 		try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + metadataFilePath)) {
 			try (Statement stmt = conn.createStatement()) {
 				stmt.execute("CREATE TABLE IF NOT EXISTS metadata(key TEXT, value TEXT);");
+				seedMetadataVersionIfAbsent(stmt);
 			}
 		}
+	}
+
+	private static void seedMetadataVersionIfAbsent(Statement stmt) throws SQLException {
+		try (ResultSet rs = stmt.executeQuery(
+				"SELECT value FROM metadata WHERE key = '" + SYNCLITE_METADATA_VERSION_KEY + "'")) {
+			if (rs.next()) {
+				return;
+			}
+		}
+		stmt.execute("INSERT INTO metadata(key, value) VALUES('"
+				+ SYNCLITE_METADATA_VERSION_KEY + "', '" + SYNCLITE_METADATA_VERSION + "')");
 	}
 
 	public static MetadataManager getInstance(Path metadataFilePath) throws SQLException {

--- a/root/core/src/main/java/com/synclite/consolidator/global/MetadataRetry.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/MetadataRetry.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Mirrors the retry envelope used by Rust's `retry_dst(...)` so that every
+ * consolidator metadata write is uniformly guarded against transient dst
+ * failures.
+ */
+package com.synclite.consolidator.global;
+
+import org.apache.log4j.Logger;
+
+public final class MetadataRetry {
+    private MetadataRetry() {}
+
+    @FunctionalInterface
+    public interface MetadataOp<E extends Exception> {
+        void run() throws E;
+    }
+
+    public static <E extends Exception> void retry(
+            int dstIndex, Logger tracer, String opName, MetadataOp<E> op) throws E {
+        long retryCount = Math.max(1L, ConfLoader.getInstance().getDstOperRetryCount(dstIndex));
+        long retryIntervalMs = ConfLoader.getInstance().getDstOperRetryIntervalMs(dstIndex);
+        for (long i = 0; i < retryCount; ++i) {
+            try {
+                op.run();
+                return;
+            } catch (Exception e) {
+                if (i == retryCount - 1) {
+                    @SuppressWarnings("unchecked")
+                    E typed = (E) e;
+                    throw typed;
+                }
+                try {
+                    Thread.sleep(retryIntervalMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+                if (tracer != null) {
+                    tracer.info("Retry attempt : " + (i + 2) + " : Retrying metadata op " + opName
+                            + " after exception : " + e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
@@ -23,25 +23,35 @@ import com.synclite.consolidator.schema.TableID;
 public class SyncLiteConsolidatorInfo {
 
     public static TableID getCheckpointTableID(String deviceUUID, String deviceName, int dstIndex) {
-        return TableID.from(deviceUUID, deviceName, dstIndex, "main", null, getSyncLiteMetadataTableName());
+        return TableID.from(deviceUUID, deviceName, dstIndex, "main", null, getSyncLiteCheckpointTableName());
     }
 
-    public static String getSyncLiteMetadataTableName() {
-    	return "synclite_metadata";
+    public static String getSyncLiteCheckpointTableName() {
+    	return "synclite_checkpoint";
     }
 
-    public static String getTableSchemaTableName() {
-    	return "synclite_table_schema";
+    /**
+     * Name of the unified per-table metadata bookkeeping table on the destination.
+     * Per-table source DDL is stored as {@code prop_key='create_sql'} rows here.
+     */
+    public static String getConsolidatorTableMetadataTableName() {
+    	return "synclite_consolidator_table_metadata";
     }
 
-    public static String getCreateTableSchemaTableSql() {
-    	return "CREATE TABLE IF NOT EXISTS synclite_table_schema("
-    		+ "device_uuid VARCHAR(36) NOT NULL, "
+    public static String getCreateConsolidatorTableMetadataTableSql() {
+    	return "CREATE TABLE IF NOT EXISTS synclite_consolidator_table_metadata("
+    		+ "device_uuid VARCHAR(64) NOT NULL, "
     		+ "device_name VARCHAR(255) NOT NULL, "
-    		+ "dst_index INTEGER NOT NULL, "
+    		+ "database_name VARCHAR(255) NOT NULL, "
     		+ "table_name VARCHAR(255) NOT NULL, "
-    		+ "create_sql TEXT, "
-    		+ "PRIMARY KEY(device_uuid, device_name, dst_index, table_name))";
+    		+ "prop_key VARCHAR(255) NOT NULL, "
+    		+ "prop_value TEXT, "
+    		+ "PRIMARY KEY(device_uuid, device_name, database_name, table_name, prop_key))";
+    }
+
+    /** Reserved {@code prop_key} value carrying the per-table CREATE SQL blob. */
+    public static String getCreateSqlPropKey() {
+    	return "create_sql";
     }
 
     public static String getMetadataFileName(int dstIndex) {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
@@ -36,6 +36,7 @@ import com.synclite.consolidator.exception.DstDuplicateKeyException;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.global.ConfLoader;
+import com.synclite.consolidator.global.MetadataRetry;
 import com.synclite.consolidator.global.DstSyncMode;
 import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
 import com.synclite.consolidator.log.CDCLogPosition;
@@ -85,7 +86,7 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 	/**
 	 * Initialises the local checkpoint table (LOCAL mode only).
 	 * In DESTINATION mode the checkpoint lives on the destination DB and needs no local setup here.
-	 * In LOCAL mode also blocks synclite_metadata from being re-created on the destination.
+	 * In LOCAL mode also blocks synclite_checkpoint from being re-created on the destination.
 	 */
 	private final void initCheckpointTableIfNeeded() throws SyncLiteException {
 		if (ConfLoader.getInstance().getDstDisableMetadataTable(dstIndex)) {
@@ -100,12 +101,12 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 			} catch (SyncLiteException e) {
 				throw new SyncLiteException("Failed to initialize the checkpoint table in SyncLite consolidator metadata file : ", e);
 			}
-			// Block synclite_metadata from being created on destination in LOCAL mode
+			// Block synclite_checkpoint from being created on destination in LOCAL mode
 			ConsolidatorSrcTable replicatorCheckpointTable = ConsolidatorSrcTable.from(
 					SyncLiteConsolidatorInfo.getCheckpointTableID(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex));
 			ConfLoader.getInstance().blockTable(dstIndex, replicatorCheckpointTable.id.table);
 		}
-		// DESTINATION mode: synclite_metadata lives on destination, created during snapshot consolidation
+		// DESTINATION mode: synclite_checkpoint lives on destination, created during snapshot consolidation
 	}
 
 	private final void reloadCheckpointInfo() throws SyncLiteException {
@@ -143,7 +144,7 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 						Long.valueOf(checkpointInfo.get("txn_count").toString()));
 			}
 		} else {
-			// DESTINATION mode: read checkpoint from destination synclite_metadata table
+			// DESTINATION mode: read checkpoint from destination synclite_checkpoint table
 			for (long i = 0; i < ConfLoader.getInstance().getDstOperRetryCount(dstIndex); ++i) {
 				try {
 					try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, this.dstIndex, device.tracer)) {
@@ -351,7 +352,8 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 			Path targetPath = failedLogDir.resolve(currentCDCLogSegment.path.getFileName());
 			Files.copy(currentCDCLogSegment.path, targetPath, StandardCopyOption.REPLACE_EXISTING);
 
-			consolidatorMetadataMgr.updateLastConsolidatedCDCLogSegmentSeqNum(currentCDCLogSegment.sequenceNumber);
+			MetadataRetry.retry(dstIndex, device.tracer, "updateLastConsolidatedCDCLogSegmentSeqNum",
+					() -> consolidatorMetadataMgr.updateLastConsolidatedCDCLogSegmentSeqNum(currentCDCLogSegment.sequenceNumber));
 			
 			this.lastConsolidatedChangeNumber = -1;
 			device.tracer.info("Skipped failed log segment : " + currentCDCLogSegment);
@@ -792,8 +794,10 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 
 	private final void resetSchemas() throws SyncLiteException {
 		try {
-			consolidatorMetadataMgr.resetTableMetadata();
-			consolidatorMetadataMgr.resetSchemas();
+			MetadataRetry.retry(dstIndex, device.tracer, "resetTableMetadata",
+					() -> consolidatorMetadataMgr.resetTableMetadata());
+			MetadataRetry.retry(dstIndex, device.tracer, "resetSchemas",
+					() -> consolidatorMetadataMgr.resetSchemas());
 		} catch (SQLException e) {
 			throw new SyncLiteException("Failed to reset schema and metadata tables in consolidator metadata file : " + consolidatorMetadataMgr.getMetadataFilePath());
 		}

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceDstInitializer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceDstInitializer.java
@@ -220,11 +220,15 @@ public class DeviceDstInitializer {
 			if (srcTable == logReaderCheckpointTable) {
 				continue;
 			}
-			
-			if (ConfLoader.getInstance().getDstDisableMetadataTable(dstIndex)) {
-				if (srcTable == consolidatorCheckpointTable) {
-					continue;
-				}
+
+			// Always skip the consolidator's own checkpoint table from the snapshot-init loop.
+			// In LOCAL mode the checkpoint is stored in the local metadata file. In DESTINATION
+			// mode the checkpoint table on the destination is owned by DeviceSyncProcessor
+			// (see ensureDstMetadataInitStatusColumn / persistInitializationStatusToDst); the
+			// snapshot init path must not write create_sql / initialization_status / initial_rows
+			// rows for it into synclite_consolidator_table_metadata.
+			if (srcTable == consolidatorCheckpointTable) {
+				continue;
 			}
 
 			if (! ConfLoader.getInstance().isAllowedTable(dstIndex, srcTable.id.table)) {
@@ -270,10 +274,9 @@ public class DeviceDstInitializer {
 				continue;
 			}
 
-			if (ConfLoader.getInstance().getDstDisableMetadataTable(dstIndex)) {
-				if (srcTable == consolidatorCheckpointTable) {
-					continue;
-				}
+			// Always skip the consolidator's own checkpoint table — owned by DeviceSyncProcessor.
+			if (srcTable == consolidatorCheckpointTable) {
+				continue;
 			}
 
 			if (! ConfLoader.getInstance().isAllowedTable(dstIndex, srcTable.id.table)) {
@@ -307,10 +310,9 @@ public class DeviceDstInitializer {
 					continue;
 				}
 
-				if (ConfLoader.getInstance().getDstDisableMetadataTable(dstIndex)) {
-					if (srcTable == consolidatorCheckpointTable) {
-						continue;
-					}
+				// Always skip the consolidator's own checkpoint table — owned by DeviceSyncProcessor.
+				if (srcTable == consolidatorCheckpointTable) {
+					continue;
 				}
 
 				if (! ConfLoader.getInstance().isAllowedTable(dstIndex, srcTable.id.table)) {
@@ -336,8 +338,9 @@ public class DeviceDstInitializer {
 					}
 					dstExecutor.beginTran();
 					dstExecutor.execute(tableMapper.mapOper(new CreateTable(srcTable)));
-					// In DESTINATION metadata mode, persist schema to synclite_table_schema
-					// so that loadSchemasFromDestination() can reconstruct column lists on restart.
+					// In DESTINATION metadata mode, persist schema as a create_sql row in
+					// synclite_consolidator_table_metadata so loadSchemasFromDestination()
+					// can reconstruct column lists on restart.
 					if (syncProcessor != null) {
 						syncProcessor.persistSchemaToDst(dstExecutor, srcTable);
 					}

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
@@ -373,7 +373,7 @@ public class DeviceStatsCollector {
 	}
 
 	private boolean shouldTrackTableStats(TableID tableID) {
-		return tableID != null && !SyncLiteConsolidatorInfo.getSyncLiteMetadataTableName().equalsIgnoreCase(tableID.table);
+		return tableID != null && !SyncLiteConsolidatorInfo.getSyncLiteCheckpointTableName().equalsIgnoreCase(tableID.table);
 	}
 
 	//Method specifically for REPLICATION TO SQLITE usecase 

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceSyncProcessor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceSyncProcessor.java
@@ -31,6 +31,7 @@ import com.synclite.consolidator.device.Device;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.global.ConfLoader;
+import com.synclite.consolidator.global.MetadataRetry;
 import com.synclite.consolidator.global.ConsolidatorMetadataManager;
 import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
 import com.synclite.consolidator.oper.Insert;
@@ -53,13 +54,13 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 
 	// ── Shared SQL constants ───────────────────────────────────────────────────
 	public static final String createTxnTableSql =
-		"CREATE TABLE IF NOT EXISTS synclite_metadata(commit_id LONG NOT NULL PRIMARY KEY, " +
+		"CREATE TABLE IF NOT EXISTS synclite_checkpoint(commit_id LONG NOT NULL PRIMARY KEY, " +
 		"cdc_change_number LONG NOT NULL, " +
 		"cdc_log_segment_sequence_number LONG NOT NULL, " +
 		"initialization_status LONG NOT NULL DEFAULT 0, " +
 		"txn_count LONG NOT NULL)";
 	public static final String createDstTxnTableSql =
-		"CREATE TABLE IF NOT EXISTS synclite_metadata(" +
+		"CREATE TABLE IF NOT EXISTS synclite_checkpoint(" +
 		"synclite_device_id TEXT NOT NULL, " +
 		"synclite_device_name TEXT NOT NULL, " +
 		"synclite_update_timestamp TEXT, " +
@@ -71,13 +72,13 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		"PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))";
 	public static final String selectTxnTableSql =
 		"SELECT commit_id, cdc_change_number, cdc_log_segment_sequence_number, txn_count " +
-		"FROM synclite_metadata";
+		"FROM synclite_checkpoint";
 	public static final String insertTxnTableSql =
-		"INSERT INTO synclite_metadata(" +
+		"INSERT INTO synclite_checkpoint(" +
 		"commit_id, cdc_change_number, cdc_log_segment_sequence_number, txn_count" +
 		") VALUES($1, -1, 0, 0);";
 	protected static final String updateTxnTableSql =
-		"UPDATE synclite_metadata SET commit_id = ?, cdc_change_number = ?, " +
+		"UPDATE synclite_checkpoint SET commit_id = ?, cdc_change_number = ?, " +
 		"cdc_log_segment_sequence_number = ?, txn_count = ?";
 
 	// ── Where metadata is stored ───────────────────────────────────────────────
@@ -225,7 +226,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		boolean recreate = false;
 		try {
 			dstExecutor.execute(new NativeOper(null,
-					"SELECT synclite_device_id, synclite_device_name, initialization_status FROM synclite_metadata WHERE 1 = 0"));
+					"SELECT synclite_device_id, synclite_device_name, initialization_status FROM synclite_checkpoint WHERE 1 = 0"));
 		} catch (DstExecutionException e) {
 			String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
 			if (msg.contains("no such column") || msg.contains("unknown column") || msg.contains("invalid identifier")) {
@@ -237,7 +238,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		if (!recreate) {
 			try {
 				dstExecutor.execute(new NativeOper(null,
-						"SELECT command_log_change_number FROM synclite_metadata WHERE 1 = 0"));
+						"SELECT command_log_change_number FROM synclite_checkpoint WHERE 1 = 0"));
 				recreate = true;
 			} catch (DstExecutionException e) {
 				String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
@@ -248,7 +249,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		}
 		if (recreate) {
 			// Recreate incompatible or legacy checkpoint table schema in one shot (no ALTER path).
-			dstExecutor.execute(new NativeOper(null, "DROP TABLE IF EXISTS synclite_metadata"));
+			dstExecutor.execute(new NativeOper(null, "DROP TABLE IF EXISTS synclite_checkpoint"));
 			dstExecutor.execute(new NativeOper(null, createDstTxnTableSql));
 		}
 		dstExecutor.commitTran();
@@ -261,7 +262,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		String uuid  = device.getDeviceUUID().replace("'", "''");
 		String dname = device.getDeviceName().replace("'", "''");
 		dstExecutor.execute(new NativeOper(null,
-				"UPDATE synclite_metadata SET initialization_status = " + status
+				"UPDATE synclite_checkpoint SET initialization_status = " + status
 				+ " WHERE synclite_device_id = '" + uuid
 				+ "' AND synclite_device_name = '" + dname + "'"));
 	}
@@ -277,7 +278,8 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 				device.getDeviceUUID(), device.getDeviceName(), this.dstIndex);
 		if (dstStatus == 1) {
 			try {
-				consolidatorMetadataMgr.updateInitializedSnapshotName("restored");
+				MetadataRetry.retry(dstIndex, device.tracer, "updateInitializedSnapshotName",
+						() -> consolidatorMetadataMgr.updateInitializedSnapshotName("restored"));
 			} catch (SyncLiteException e) {
 				throw new SyncLiteException("Failed to restore initialization status from destination : ", e);
 			}
@@ -286,9 +288,14 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 
 	// ── Schema-on-destination helpers ─────────────────────────────────────────
 
+	/**
+	 * Ensures the unified per-table metadata table exists on the destination.
+	 * Per-table source DDL is stored as {@code prop_key='create_sql'} rows in
+	 * {@code synclite_consolidator_table_metadata}.
+	 */
 	protected void ensureDstSchemaTableExists(SQLExecutor dstExecutor) throws DstExecutionException {
 		if (dstSchemaTableInitialized) return;
-		dstExecutor.execute(new NativeOper(null, SyncLiteConsolidatorInfo.getCreateTableSchemaTableSql()));
+		dstExecutor.execute(new NativeOper(null, SyncLiteConsolidatorInfo.getCreateConsolidatorTableMetadataTableSql()));
 		dstExecutor.commitTran();
 		dstExecutor.beginTran();
 		dstSchemaTableInitialized = true;
@@ -298,10 +305,13 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		ensureDstSchemaTableExists(dstExecutor);
 		List<String[]> rows = dstExecutor.readTableSchemas(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex);
 		for (String[] row : rows) {
-			String tableName = row[0];
-			String createSql = row[1];
+			// row = [database_name, table_name, create_sql]
+			String dbName    = (row.length > 2) ? row[0] : "main";
+			String tableName = (row.length > 2) ? row[1] : row[0];
+			String createSql = (row.length > 2) ? row[2] : row[1];
 			if (createSql == null || createSql.isBlank()) continue;
-			TableID id = TableID.from(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex, "main", null, tableName);
+			TableID id = TableID.from(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex,
+					(dbName == null || dbName.isEmpty()) ? "main" : dbName, null, tableName);
 			ConsolidatorSrcTable srcTable = ConsolidatorSrcTable.from(id);
 			srcTable.sql = createSql;
 			// Execute CREATE SQL on in-memory replica so PRAGMA table_info can resolve columns
@@ -339,29 +349,35 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		ensureDstSchemaTableExists(dstExecutor);
 		String uuid  = device.getDeviceUUID().replace("'", "''");
 		String dname = device.getDeviceName().replace("'", "''");
+		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database).replace("'", "''");
 		String tname = srcTable.id.table.replace("'", "''");
-		String sql   = srcTable.sql != null ? srcTable.sql : buildCreateSqlFromColumns(srcTable);
-		String csql  = (sql != null ? sql : "").replace("'", "''");
+		// Always derive the DDL from the current column model — srcTable.sql is set once
+		// from the original CREATE on restart and never refreshed by apply*Column, so it
+		// would drift after any ADDCOLUMN / DROPCOLUMN / ALTERCOLUMN / RENAMECOLUMN.
+		String csql  = buildCreateSqlFromColumns(srcTable).replace("'", "''");
 		dstExecutor.execute(new NativeOper(null,
-				"DELETE FROM synclite_table_schema WHERE device_uuid = '" + uuid
+				"DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = '" + uuid
 				+ "' AND device_name = '" + dname
-				+ "' AND dst_index = " + dstIndex
-				+ " AND table_name = '" + tname + "'"));
+				+ "' AND database_name = '" + dbname
+				+ "' AND table_name = '" + tname
+				+ "' AND prop_key = 'create_sql'"));
 		dstExecutor.execute(new NativeOper(null,
-				"INSERT INTO synclite_table_schema(device_uuid, device_name, dst_index, table_name, create_sql) VALUES('"
-				+ uuid + "', '" + dname + "', " + dstIndex + ", '" + tname + "', '" + csql + "')"));
+				"INSERT INTO synclite_consolidator_table_metadata(device_uuid, device_name, database_name, table_name, prop_key, prop_value) VALUES('"
+				+ uuid + "', '" + dname + "', '" + dbname + "', '" + tname + "', 'create_sql', '" + csql + "')"));
 	}
 
 	protected void deleteSchemaFromDst(SQLExecutor dstExecutor, ConsolidatorSrcTable srcTable) throws DstExecutionException {
 		if (!dstSchemaTableInitialized) return;
 		String uuid  = device.getDeviceUUID().replace("'", "''");
 		String dname = device.getDeviceName().replace("'", "''");
+		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database).replace("'", "''");
 		String tname = srcTable.id.table.replace("'", "''");
 		dstExecutor.execute(new NativeOper(null,
-				"DELETE FROM synclite_table_schema WHERE device_uuid = '" + uuid
+				"DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = '" + uuid
 				+ "' AND device_name = '" + dname
-				+ "' AND dst_index = " + dstIndex
-				+ " AND table_name = '" + tname + "'"));
+				+ "' AND database_name = '" + dbname
+				+ "' AND table_name = '" + tname
+				+ "' AND prop_key = 'create_sql'"));
 	}
 
 	protected String buildCreateSqlFromColumns(ConsolidatorSrcTable srcTable) {
@@ -449,7 +465,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	private Column getCheckpointColumn(String columnName) throws SyncLiteException {
 		Column col = checkpointTable.colMap.get(columnName);
 		if (col == null) {
-			throw new SyncLiteException("Missing checkpoint column in synclite_metadata: " + columnName);
+			throw new SyncLiteException("Missing checkpoint column in synclite_checkpoint: " + columnName);
 		}
 		return col;
 	}

--- a/root/core/src/main/java/com/synclite/consolidator/processor/JDBCExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/JDBCExecutor.java
@@ -1543,13 +1543,13 @@ public abstract class JDBCExecutor extends SQLExecutor {
 	@Override
 	public List<String[]> readTableSchemas(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {
 		List<String[]> schemas = new ArrayList<>();
-		String sql = "SELECT table_name, create_sql FROM synclite_table_schema WHERE device_uuid = '"
+		String sql = "SELECT database_name, table_name, prop_value FROM synclite_consolidator_table_metadata WHERE device_uuid = '"
 				+ deviceUUID.replace("'", "''") + "' AND device_name = '"
-				+ deviceName.replace("'", "''") + "' AND dst_index = " + dstIdx;
+				+ deviceName.replace("'", "''") + "' AND prop_key = 'create_sql'";
 		try (Statement stmt = conn.createStatement();
 				ResultSet rs = stmt.executeQuery(sql)) {
 			while (rs.next()) {
-				schemas.add(new String[]{rs.getString(1), rs.getString(2)});
+				schemas.add(new String[]{rs.getString(1), rs.getString(2), rs.getString(3)});
 			}
 		} catch (SQLException e) {
 			// Table may not exist yet on a completely fresh device — return empty
@@ -1561,7 +1561,7 @@ public abstract class JDBCExecutor extends SQLExecutor {
 	public long readInitializationStatus(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {
 		String uuid = deviceUUID.replace("'", "''");
 		String dname = deviceName.replace("'", "''");
-		String sql = "SELECT initialization_status FROM synclite_metadata WHERE synclite_device_id = '"
+		String sql = "SELECT initialization_status FROM synclite_checkpoint WHERE synclite_device_id = '"
 				+ uuid + "' AND synclite_device_name = '" + dname + "' ORDER BY commit_id DESC LIMIT 1";
 		try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql)) {
 			if (rs.next()) {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/SQLExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/SQLExecutor.java
@@ -131,8 +131,10 @@ public abstract class SQLExecutor implements AutoCloseable{
     protected abstract CDCLogPosition readCDCLogPosition(String deviceUUID, String deviceName, ConsolidatorDstTable dstCheckpointTable) throws DstExecutionException;
 
     /**
-     * Read per-table CREATE SQL strings from the destination's synclite_table_schema system table.
-     * Returns a list of two-element arrays: [table_name, create_sql].
+     * Read per-table CREATE SQL strings from the destination's
+     * {@code synclite_consolidator_table_metadata} system table
+     * (rows with {@code prop_key='create_sql'}).
+     * Returns a list of three-element arrays: [database_name, table_name, create_sql].
      * Default: returns empty list (non-JDBC / unsupported destinations fall back gracefully).
      */
     public List<String[]> readTableSchemas(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {
@@ -140,7 +142,7 @@ public abstract class SQLExecutor implements AutoCloseable{
     }
 
     /**
-     * Read initialization status from destination synclite_metadata.
+     * Read initialization status from destination synclite_checkpoint.
      * Returns 1 if initialized, 0 if not, -1 if not supported / table does not exist yet.
      */
     public long readInitializationStatus(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {


### PR DESCRIPTION
# PR Description - synclite-consolidator

## Summary
BREAKING CHANGE: Metadata and checkpoint refactor for consolidation flow, plus rename alignment and snapshot-only recovery behavior updates.

## What Changed
- Updated consolidator metadata handling and checkpoint access:
  - `root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java`
  - `root/core/src/main/java/com/synclite/consolidator/global/MetadataManager.java`
  - `root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java`
- Updated processor stack for checkpoint/device sync behavior:
  - `DeviceConsolidator.java`
  - `DeviceDstInitializer.java`
  - `DeviceSyncProcessor.java`
  - `DeviceStatsCollector.java`
  - `JDBCExecutor.java`
  - `SQLExecutor.java`
- Updated config loader logic in `ConfLoader.java`.
- Folded destination-side metadata from three tables into two:
  - Removed `synclite_source_table_schemas` (declared in `SyncLiteConsolidatorInfo` as `getSourceTableSchemasTableName` / `getCreateSourceTableSchemasTableSql`).
  - Per-table DDL now lives in `synclite_consolidator_table_metadata` as rows with reserved `prop_key='create_sql'` (constant `SyncLiteConsolidatorInfo.getCreateSqlPropKey()`), keyed by `(device_uuid, device_name, database_name, table_name, prop_key)`.
  - `DeviceSyncProcessor.persistSchemaToDst` / `deleteSchemaFromDst` / `loadSchemasFromDestination` and `JDBCExecutor.readTableSchemas` rewritten against the unified table; legacy reader added as `JDBCExecutor.readLegacyTableSchemas` (SQLException-tolerant) and surfaced via `SQLExecutor.readLegacyTableSchemas`.
  - `ConsolidatorMetadataManager.deleteSchemaInfo` / `resetSchemas` (destination branch) now ensure the unified table and delete only `prop_key='create_sql'` rows.
  - Idempotent migration shim `DeviceSyncProcessor.migrateLegacySchemasIfNeeded` copies any legacy `synclite_source_table_schemas` rows into the unified table on first contact and stamps `synclite_consolidator_metadata` with `prop_key='schemas_folded_v1'`, `prop_value='1'`.
- Stopped writing bookkeeping rows for the consolidator's own `synclite_checkpoint` table into the per-table metadata:
  - `DeviceDstInitializer.initializeTables` / `cleanupTables` / `initializeDataLakeTables` now skip `synclite_checkpoint` unconditionally (previously only when `dst-disable-metadata-table=true`), so the snapshot-init path no longer writes redundant `create_sql`, `initialization_status`, or `initial_rows` rows into `synclite_consolidator_table_metadata`. The checkpoint table remains owned by `DeviceSyncProcessor.ensureDstMetadataInitStatusColumn`, which uses the canonical `createDstTxnTableSql` DDL.
- Closed a seed-time gap that could leave the `synclite_metadata_version` row missing on the destination:
  - `ConsolidatorMetadataManager.ensureDstTableMetadataTable` now also invokes `seedDstMetadataVersionIfAbsent`, so the version row is written whenever any per-table-metadata write touches the kv tables (previously only the device-property path seeded it).

## Impact
- Consolidator behavior is now consistent with checkpoint-based metadata and renamed logger/runtime entities.
- Snapshot and CDC consolidation paths are cleaner and easier to reason about.
- Destination metadata footprint reduced from three bookkeeping tables to two; per-table DDL is now stored alongside the rest of the per-table properties instead of in a parallel dictionary.

## Risks
- Any mismatch between old metadata schema and checkpoint migration assumptions can affect replay behavior.
