### PR TITLE
Fold per-device metadata into consolidator metadata

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/device/Device.java
+++ b/root/core/src/main/java/com/synclite/consolidator/device/Device.java
@@ -537,10 +537,8 @@ public class Device {
 	private Path remoteCommandPath;
 	private HashMap<Integer, Path> failedLogSegmentsDirectoryPaths = new HashMap<Integer, Path>();
 	private String dbName;
-	private long dbID;
 	private String deviceName;
 	private DeviceType deviceType;
-	private int allowsConcurrentWriters;
 	private DeviceStatus status;
 	private String statusDescription;
 	private String detectionTime;
@@ -548,7 +546,6 @@ public class Device {
 	private String lastStatusUpdateTime;
 	private long lastHeartbeatTS;
 	private MetadataManager loggerMetadataMgr;
-	private MetadataManager deviceMetadataMgr;
 	private HashMap<Integer, ConsolidatorMetadataManager> consolidatorMetadataMgrs = new HashMap<Integer, ConsolidatorMetadataManager>();
 	private volatile long lastReplicatedCommitID;
 	private volatile long lastConsolidatedCommitID;
@@ -599,7 +596,7 @@ public class Device {
 
 		initializeDstIndexes();    
 		initializeConsolidatorMetadataFile();
-		initializeDeviceMetadataFile();
+		initializeDeviceMetadata();
 		initializeDeviceStatsCollector();
 		if (this.status != DeviceStatus.UNREGISTERED) {
 			Monitor.getInstance().incrRegisteredDeviceCnt(1L);
@@ -612,7 +609,7 @@ public class Device {
 
 		initializeCommandDirectory();	
 		initializeFailedLogDirectory();
-		Monitor.getInstance().incrResynchronizationCnt(this.dbID);
+		Monitor.getInstance().incrResynchronizationCnt(1);
 		this.tracer.info("Device initialized with status : " + this.status);
 	}
 
@@ -804,7 +801,13 @@ public class Device {
 	}
 
 	public Boolean allowsConcurrentWriters() {
-		return (this.allowsConcurrentWriters == 1);
+		switch (this.deviceType) {
+		case SQLITE:
+		case SQLITE_STORE:
+			return false;
+		default:
+			return true;
+		}
 	}
 	
 	public Path getDeviceDataRoot() {
@@ -847,12 +850,59 @@ public class Device {
 		return this.loggerMetadataMgr;
 	}
 
-	public MetadataManager getDeviceMetadataMgr() {
-		return this.deviceMetadataMgr;
-	}
-
 	public ConsolidatorMetadataManager getConsolidatorMetadataMgr(int dstIndex) {
 		return this.consolidatorMetadataMgrs.get(dstIndex);
+	}
+
+	/**
+	 * Device-level metadata is folded into every consolidator metadata file (one
+	 * per destination). Writes go to all dsts so the value stays consistent; reads
+	 * come from the first dst.
+	 */
+	public void upsertDeviceMetadataProperty(String key, Object value) throws SQLException {
+		SQLException firstFailure = null;
+		for (int dstIndex : allDstIndexes) {
+			try {
+				consolidatorMetadataMgrs.get(dstIndex).upsertProperty(key, value);
+			} catch (SQLException e) {
+				if (firstFailure == null) {
+					firstFailure = e;
+				}
+			}
+		}
+		if (firstFailure != null) {
+			throw firstFailure;
+		}
+	}
+
+	public void deleteDeviceMetadataProperty(String key) throws SQLException {
+		SQLException firstFailure = null;
+		for (int dstIndex : allDstIndexes) {
+			try {
+				consolidatorMetadataMgrs.get(dstIndex).deleteProperty(key);
+			} catch (SQLException e) {
+				if (firstFailure == null) {
+					firstFailure = e;
+				}
+			}
+		}
+		if (firstFailure != null) {
+			throw firstFailure;
+		}
+	}
+
+	public String getDeviceMetadataStringProperty(String key) throws SQLException {
+		if (allDstIndexes.isEmpty()) {
+			return null;
+		}
+		return consolidatorMetadataMgrs.get(allDstIndexes.get(0)).getStringProperty(key);
+	}
+
+	public Long getDeviceMetadataLongProperty(String key) throws SQLException {
+		if (allDstIndexes.isEmpty()) {
+			return null;
+		}
+		return consolidatorMetadataMgrs.get(allDstIndexes.get(0)).getLongProperty(key);
 	}
 
 	private boolean disablePeriodicSnapshots() {
@@ -979,76 +1029,70 @@ public class Device {
 		}
 	}
 
-	private final void initializeDeviceMetadataFile() throws SyncLiteException {
-		Path deviceMetadataFile = Path.of(rootPath.toString(), SyncLiteDeviceInfo.getMetadataFileName());
-		try {
-			deviceMetadataMgr = MetadataManager.getInstance(deviceMetadataFile);
-		} catch (SQLException e) {
-			throw new SyncLiteException("Bad device. Failed to open device metadata file : " + deviceMetadataFile, e);
-		}
-
+	private final void initializeDeviceMetadata() throws SyncLiteException {
 		try {
 
-			String strVal = deviceMetadataMgr.getStringProperty("database_name");
+			String strVal = getDeviceMetadataStringProperty("database_name");
 			if (strVal != null) {
 				this.dbName = strVal;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("device_type");
+			strVal = getDeviceMetadataStringProperty("device_type");
 			if (strVal != null) {
 				this.deviceType = DeviceType.valueOf(strVal);
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("device_name");
+			strVal = getDeviceMetadataStringProperty("device_name");
 			if (strVal != null) {
 				if (!this.deviceName.equals(strVal)) {
-					throw new SyncLiteException("Bad device. Device name mismatch in device root and metadata file : " + deviceMetadataFile);
+					throw new SyncLiteException("Bad device. Device name mismatch in device root and consolidator metadata for device : " + this.deviceName);
 				}
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("allow_concurrent_writers");
-			if (strVal != null) {
-				this.allowsConcurrentWriters = Integer.valueOf(strVal);
-			} else {
-				this.allowsConcurrentWriters = 0;
-			}
-
-			strVal = deviceMetadataMgr.getStringProperty("registered_time");
+			strVal = getDeviceMetadataStringProperty("registered_time");
 			if (strVal != null) {
 				this.registeredTime = strVal;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("detection_time");
+			strVal = getDeviceMetadataStringProperty("detection_time");
 			if (strVal != null) {
 				this.detectionTime = strVal;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("last_status_update_time");
+			strVal = getDeviceMetadataStringProperty("last_status_update_time");
 			if (strVal != null) {
 				this.lastStatusUpdateTime = strVal;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("status_description");
+			strVal = getDeviceMetadataStringProperty("status_description");
 			if (strVal != null) {
 				this.statusDescription = strVal;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("status");
+			// Status is metadata, not statistics. Source of truth lives in the
+			// consolidator metadata store so it survives a missing/corrupt
+			// stats file. The mirror in device_statistics.status is for GUI
+			// rendering only.
+			strVal = getDeviceMetadataStringProperty("device_status");
 			if (strVal != null) {
-				this.status = DeviceStatus.valueOf(strVal);
+				try {
+					this.status = DeviceStatus.valueOf(strVal);
+				} catch (IllegalArgumentException ignored) {
+					this.status = DeviceStatus.UNREGISTERED;
+				}
 			} else {
-				this.status = DeviceStatus.valueOf("UNREGISTERED");
+				this.status = DeviceStatus.UNREGISTERED;
 			}
 
-			strVal = deviceMetadataMgr.getStringProperty("data_backup_snapshot");
+			strVal = getDeviceMetadataStringProperty("data_backup_snapshot");
 			if (strVal != null) {
 				this.backupSnapshot = Path.of(strVal);
 			} else {
 				this.backupSnapshot = null;
 			}
-			
+
 		} catch (SQLException e) {
-			throw new SyncLiteException("Bad device. Failed to read/write records in metadata file.", e);
+			throw new SyncLiteException("Bad device. Failed to read records from consolidator metadata.", e);
 		}
 	}
 
@@ -1224,35 +1268,6 @@ public class Device {
 		}
 
 		try {
-			String allowConcurrentWritersStr = loggerMetadataMgr.getStringProperty("allow_concurrent_writers");
-			if (allowConcurrentWritersStr == null) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Allow Concurrent Writers property missing in the metadata file : " + loggerMetadataMgr.getMetadataFilePath());
-				return false;
-			} else {
-				this.allowsConcurrentWriters = Integer.valueOf(allowConcurrentWritersStr);
-				if (deviceType == null) {
-					updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Allow Concurrent Writers property missing in the metadata file : " + loggerMetadataMgr.getMetadataFilePath());
-					return false;
-				}
-			}
-		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to read device_type record in the metadata file");
-			return false;
-		}
-
-		try {
-			Long databaseID = loggerMetadataMgr.getLongProperty("database_id");
-			if (databaseID == null) {
-				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to find database_id record in the metadata file");
-				return false;
-			}
-			this.dbID = databaseID;
-		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to read database_id record in the metadata file");
-			return false;
-		}
-
-		try {
 			Long backupShipped = loggerMetadataMgr.getLongProperty("backup_shipped");
 			if (backupShipped == null) {
 				updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to find backup status record in the metadata file");
@@ -1267,41 +1282,28 @@ public class Device {
 		}
 
 		try {
-			deviceMetadataMgr.upsertProperty("database_name", this.dbName);
+			upsertDeviceMetadataProperty("database_name", this.dbName);
 		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write database_name record in the replicator metadata file");
+			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write database_name record in the consolidator metadata file");
 		}
 
 		try {
-			deviceMetadataMgr.upsertProperty("device_name", this.deviceName);
+			upsertDeviceMetadataProperty("device_name", this.deviceName);
 		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write database_name record in the replicator metadata file");
+			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_name record in the consolidator metadata file");
 		}
 
 		try {
-			deviceMetadataMgr.upsertProperty("device_type", this.deviceType);
+			upsertDeviceMetadataProperty("device_type", this.deviceType);
 		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_type record in the replicator metadata file");
+			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write device_type record in the consolidator metadata file");
 		}
 
-		try {
-			deviceMetadataMgr.upsertProperty("allow_concurrent_writers", this.allowsConcurrentWriters);
-		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write allow_concurrent_writers record in the replicator metadata file");
-		}
-
-		try {
-			deviceMetadataMgr.upsertProperty("database_id", this.dbID);
-		} catch (SQLException e) {
-			updateDeviceStatus(DeviceStatus.REGISTRATION_FAILED, "Bad device. Unable to write database_id record in the replicator metadata file");
-		}
-		
 		for(int dstIndex : allDstIndexes) {
 			HashMap<String, Object> identity = new HashMap<>();
 			identity.put("database_name", this.dbName);
 			identity.put("device_name", this.deviceName);
 			identity.put("device_type", this.deviceType);
-			identity.put("database_id", this.dbID);
 			try {
 				MetadataRetry.retry(dstIndex, tracer, "seed_consolidator_identity",
 						() -> consolidatorMetadataMgrs.get(dstIndex).upsertProperties(identity));
@@ -1341,21 +1343,21 @@ public class Device {
 	public final void updateDeviceStatus(DeviceStatus status, String statusDescription) throws SyncLiteException {
 		try {
 			this.status = status;
-			deviceMetadataMgr.upsertProperty("status", this.status.toString());
+			String statusStr = this.status.toString();
+			upsertDeviceMetadataProperty("device_status", statusStr);
 			this.statusDescription = statusDescription;
-			deviceMetadataMgr.upsertProperty("status_description", this.statusDescription);
+			upsertDeviceMetadataProperty("status_description", this.statusDescription);
 			if (status == DeviceStatus.UNREGISTERED) {
 				this.detectionTime = Instant.now().toString();
-				deviceMetadataMgr.upsertProperty("detection_time", this.detectionTime);
+				upsertDeviceMetadataProperty("detection_time", this.detectionTime);
 			} else if (status == DeviceStatus.REGISTERED) {
 				this.registeredTime = Instant.now().toString();
-				deviceMetadataMgr.upsertProperty("registered_time", this.registeredTime);
+				upsertDeviceMetadataProperty("registered_time", this.registeredTime);
 			}
 			this.lastStatusUpdateTime = Instant.now().toString();
-			deviceMetadataMgr.upsertProperty("last_status_update_time", this.lastStatusUpdateTime);
+			upsertDeviceMetadataProperty("last_status_update_time", this.lastStatusUpdateTime);
 		} catch (SQLException e) {
-			//throw new SyncLiteException("Bad device. Failed to update device status in metadata file", e);
-			//Ignore this is not fatal
+			//Ignore: not fatal.
 		}
 		Monitor.getInstance().registerChangedDevice(this);
 	}
@@ -1373,7 +1375,7 @@ public class Device {
 
 
 	public CDCLogSegment getNewCDCLogSegment(long sequenceNumber) throws SyncLiteException {
-		CDCLogSegment segment = new CDCLogSegment(this, sequenceNumber, SyncLiteDeviceInfo.getCDCLogSegmentPath(this.rootPath, this.dbName, this.dbID, sequenceNumber));
+		CDCLogSegment segment = new CDCLogSegment(this, sequenceNumber, SyncLiteDeviceInfo.getCDCLogSegmentPath(this.rootPath, this.dbName, sequenceNumber));
 		if (segment.path.toFile().exists()) {
 			segment.path.toFile().delete();
 		}
@@ -1394,7 +1396,7 @@ public class Device {
 
 	public CDCLogSegment getNextCDCLogSegmentToProcess(CDCLogSegment logSegment) throws SyncLiteException {
 		long nextLogSegmentSeqNum = logSegment.sequenceNumber + 1;
-		Path nextLogSegmentPath = SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, this.dbID, nextLogSegmentSeqNum);
+		Path nextLogSegmentPath = SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, nextLogSegmentSeqNum);
 		CDCLogSegment nextLogSegment = new CDCLogSegment(this, nextLogSegmentSeqNum, nextLogSegmentPath);
 		if (nextLogSegmentPath.toFile().exists()) {
 			//Check if the next to next cdc log segment is already created then only return this
@@ -1419,7 +1421,7 @@ public class Device {
 
 	public CDCLogSegment getNextCDCLogSegment(CDCLogSegment logSegment) {
 		long nextLogSegmentSeqNum = logSegment.sequenceNumber + 1;
-		Path nextLogSegmentPath = SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, this.dbID, nextLogSegmentSeqNum);
+		Path nextLogSegmentPath = SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, nextLogSegmentSeqNum);
 		if (nextLogSegmentPath.toFile().exists()) {
 			return new CDCLogSegment(this, logSegment.sequenceNumber + 1, nextLogSegmentPath);
 		}
@@ -1474,11 +1476,11 @@ public class Device {
 	}
 
 	public Path getCommandLogSegmentPath(long commandLogSegmentSequenceNumber) {
-		return SyncLiteLoggerInfo.getCommandLogSegmentPath(rootPath, dbName, dbID, commandLogSegmentSequenceNumber);
-	}    
+		return SyncLiteLoggerInfo.getCommandLogSegmentPath(rootPath, dbName, commandLogSegmentSequenceNumber);
+	}
 
 	public Path getCommandLogSegmentPathInUploadDir(long commandLogSegmentSequenceNumber) {
-		return SyncLiteLoggerInfo.getCommandLogSegmentPath(uploadPath, dbName, dbID, commandLogSegmentSequenceNumber);
+		return SyncLiteLoggerInfo.getCommandLogSegmentPath(uploadPath, dbName, commandLogSegmentSequenceNumber);
 	}
 
 	public CommandLogSegment getCommandLogSegment(long commandLogSegmentSequenceNumber) throws SyncLiteException {        
@@ -1493,7 +1495,7 @@ public class Device {
 				if (segment.isReadyToApply()) {
 					
 					//Now download the associated txn Files if needed
-					if (allowsConcurrentWriters == 1) {
+					if (allowsConcurrentWriters()) {
 						List<Path> txnFiles = getStageManager().findObjectsWithSuffixPrefix(uploadPath, segment.path.getFileName().toString(), SyncLiteLoggerInfo.getCommandLogTxnFileSuffix(), SyncLiteObjectType.LOG);
 						if ((txnFiles != null) && !txnFiles.isEmpty()) {
 							for (Path f : txnFiles) {
@@ -1519,7 +1521,7 @@ public class Device {
 	}
 
 	public Path getCDCLogSegmentPath(long cdcLogSegmentSequenceNumber) {
-		return SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, this.dbID, cdcLogSegmentSequenceNumber);
+		return SyncLiteDeviceInfo.getCDCLogSegmentPath(rootPath, dbName, cdcLogSegmentSequenceNumber);
 	}
 
 	public CDCLogSegment getCDCLogSegment(long cdcLogSegmentSequenceNumber) {
@@ -1531,11 +1533,11 @@ public class Device {
 	}
 
 	public Path getEventLogSegmentPath(long eventLogSegmentSequenceNumber) {
-		return SyncLiteLoggerInfo.getEventLogSegmentPath(rootPath, dbName, dbID, eventLogSegmentSequenceNumber);
+		return SyncLiteLoggerInfo.getEventLogSegmentPath(rootPath, dbName, eventLogSegmentSequenceNumber);
 	}
 
 	public Path getEventLogSegmentPathInUploadDir(long eventLogSegmentSequenceNumber) {
-		return SyncLiteLoggerInfo.getEventLogSegmentPath(uploadPath, dbName, dbID, eventLogSegmentSequenceNumber);
+		return SyncLiteLoggerInfo.getEventLogSegmentPath(uploadPath, dbName, eventLogSegmentSequenceNumber);
 	}
 
 	public EventLogSegment getEventLogSegment(long eventLogSegmentSequenceNumber) throws SyncLiteException {
@@ -1550,7 +1552,7 @@ public class Device {
 				if (segment.isReadyToApply()) {
 					
 					//Now download the associated txn Files if needed
-					if (allowsConcurrentWriters == 1) {
+					if (allowsConcurrentWriters()) {
 						List<Path> txnFiles = getStageManager().findObjectsWithSuffixPrefix(uploadPath, segment.path.getFileName().toString(), SyncLiteLoggerInfo.getEventLogTxnFileSuffix(), SyncLiteObjectType.LOG);
 						if ((txnFiles != null) && !txnFiles.isEmpty()) {
 							for (Path f : txnFiles) {
@@ -1772,14 +1774,14 @@ public class Device {
 			}
 
 			if (this.backupSnapshot != null) {
-				deviceMetadataMgr.deleteProperty("data_backup_snapshot");
+				deleteDeviceMetadataProperty("data_backup_snapshot");
 				this.backupSnapshot = null;
 			}
 
 			Path snapshotPath = SyncLiteDeviceInfo.getDataBackupSnapshotPath(this.rootPath, this.dbName);
 			Files.copy(backup, snapshotPath, StandardCopyOption.REPLACE_EXISTING);
 		
-			deviceMetadataMgr.upsertProperty("data_backup_snapshot",snapshotPath);
+			upsertDeviceMetadataProperty("data_backup_snapshot",snapshotPath);
 			this.backupSnapshot = snapshotPath;
 			
 		} catch (Exception e) {

--- a/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteDeviceInfo.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteDeviceInfo.java
@@ -24,13 +24,8 @@ public class SyncLiteDeviceInfo {
         return ".cdclog";
     }
 
-    public static Path getCDCLogSegmentPath(Path dbPath, String dbName, long dbID, long seqNum) {
-        //return Path.of(getCDCLogSegmentPrefix(dbPath, dbName) + dbID + "." + seqNum);
+    public static Path getCDCLogSegmentPath(Path dbPath, String dbName, long seqNum) {
     	return dbPath.resolve(seqNum + getCDCLogSegmentPrefix());
-    }
-
-    public static String getMetadataFileName() {
-        return "synclite_device_metadata.db";
     }
 
 	public static Path getDataBackupSnapshotPath(Path dbPath, String dbName) {

--- a/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteLoggerInfo.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteLoggerInfo.java
@@ -31,13 +31,11 @@ public final class SyncLiteLoggerInfo {
         return ".sqllog";
     }
 
-    public static Path getCommandLogSegmentPath(Path dbPath, String dbName, long dbID, long seqNum) {
-        //return Path.of(getCommandLogSegmentPrefix(dbPath, dbName) + dbID + "." + seqNum);
+    public static Path getCommandLogSegmentPath(Path dbPath, String dbName, long seqNum) {
     	return dbPath.resolve(seqNum + getCommandLogSegmentSuffix());
     }
 
-    public static Path getEventLogSegmentPath(Path dbPath, String dbName, long dbID, long seqNum) {
-        //return Path.of(getEventLogSegmentPrefix(dbPath, dbName) + dbID + "." + seqNum);
+    public static Path getEventLogSegmentPath(Path dbPath, String dbName, long seqNum) {
     	return dbPath.resolve(seqNum + getEventLogSegmentSuffix());
     }
 

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java
@@ -46,16 +46,13 @@ public class DeviceLogCleaner {
 		this.device = device;
 		// Persist + restore the cleanup watermark so a consolidator restart
 		// doesn't re-walk every segment from 0 just to discover they were
-		// already deleted. The value lives in the per-device metadata DB
-		// alongside other device-scoped keys (`status`, `database_name`,
-		// ...). Best-effort: a missing/corrupt value falls back to -1
-		// which preserves the original behavior.
+		// already deleted. The value lives in the consolidator metadata DB
+		// alongside other device-scoped keys (`database_name`, ...). Best-effort:
+		// a missing/corrupt value falls back to -1 which preserves the original behavior.
 		try {
-			if (device.getDeviceMetadataMgr() != null) {
-				Long persisted = device.getDeviceMetadataMgr().getLongProperty(LAST_CLEANED_KEY);
-				if (persisted != null && persisted >= 0L) {
-					this.cleanedUpto = persisted;
-				}
+			Long persisted = device.getDeviceMetadataLongProperty(LAST_CLEANED_KEY);
+			if (persisted != null && persisted >= 0L) {
+				this.cleanedUpto = persisted;
 			}
 		} catch (Throwable t) {
 			// Persistence is a cache; if it fails we silently fall back to
@@ -158,9 +155,7 @@ public class DeviceLogCleaner {
 		// range while the process lives; restart-after-failure simply
 		// re-walks the already-deleted range, which is harmless).
 		try {
-			if (device.getDeviceMetadataMgr() != null) {
-				device.getDeviceMetadataMgr().upsertProperty(LAST_CLEANED_KEY, newWatermark);
-			}
+			device.upsertDeviceMetadataProperty(LAST_CLEANED_KEY, newWatermark);
 		} catch (Throwable t) {
 			try {
 				device.tracer.warn("Failed to persist " + LAST_CLEANED_KEY + "=" + newWatermark + "; will retry on next cleanup cycle", t);

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
@@ -48,12 +48,12 @@ public class DeviceStatsCollector {
 	private final ConsolidatorMetadataManager consolidatorControlPropMgr;
 	private HashSet<TableID> tablesInStats = new HashSet<TableID>();
 
-	private final String createCheckpointTableSql = "CREATE TABLE IF NOT EXISTS checkpoint(dst_alias TEXT, cdc_log_segment_sequence_number LONG, is_initialization_stats_collected LONG, processed_oper_count LONG, processed_txn_count, processed_log_size LONG)";
-	private final String insertCheckpointTableSql = "INSERT INTO checkpoint(dst_alias, cdc_log_segment_sequence_number, is_initialization_stats_collected, processed_oper_count, processed_txn_count, processed_log_size) VALUES ('$', -1, 0, 0, 0, 0);";
-	private final String selectCheckpointTableSql = "SELECT cdc_log_segment_sequence_number, is_initialization_stats_collected, processed_oper_count, processed_txn_count, processed_log_size FROM checkpoint WHERE dst_alias = '$'";
-	private final String updateLogSegmentCheckpointTableSql = "UPDATE checkpoint SET cdc_log_segment_sequence_number = ?, processed_oper_count = processed_oper_count + ?, processed_txn_count = processed_txn_count + ?, processed_log_size = processed_log_size + ? WHERE dst_alias = ?";
-	private final String updateInitializationStatsCheckpointTableSql = "UPDATE checkpoint SET is_initialization_stats_collected = 1, processed_oper_count = $1, processed_txn_count = $2, processed_log_size = $3 WHERE dst_alias = '$4'";
-	private final String resetInitilizationStatsCollectedSql = "UPDATE checkpoint SET is_initialization_stats_collected = 0 WHERE dst_alias = '$'";
+	private final String createDeviceStatisticsTableSql = "CREATE TABLE IF NOT EXISTS device_statistics(dst_alias TEXT, cdc_log_segment_sequence_number LONG, is_initialization_stats_collected LONG, processed_oper_count LONG, processed_txn_count, processed_log_size LONG)";
+	private final String insertDeviceStatisticsTableSql = "INSERT INTO device_statistics(dst_alias, cdc_log_segment_sequence_number, is_initialization_stats_collected, processed_oper_count, processed_txn_count, processed_log_size) VALUES ('$', -1, 0, 0, 0, 0);";
+	private final String selectDeviceStatisticsTableSql = "SELECT cdc_log_segment_sequence_number, is_initialization_stats_collected, processed_oper_count, processed_txn_count, processed_log_size FROM device_statistics WHERE dst_alias = '$'";
+	private final String updateLogSegmentDeviceStatisticsTableSql = "UPDATE device_statistics SET cdc_log_segment_sequence_number = ?, processed_oper_count = processed_oper_count + ?, processed_txn_count = processed_txn_count + ?, processed_log_size = processed_log_size + ? WHERE dst_alias = ?";
+	private final String updateInitializationStatsDeviceStatisticsTableSql = "UPDATE device_statistics SET is_initialization_stats_collected = 1, processed_oper_count = $1, processed_txn_count = $2, processed_log_size = $3 WHERE dst_alias = '$4'";
+	private final String resetInitilizationStatsCollectedSql = "UPDATE device_statistics SET is_initialization_stats_collected = 0 WHERE dst_alias = '$'";
 	private final String createStatsTableSql = "CREATE TABLE IF NOT EXISTS table_statistics(dst_alias TEXT, database_name TEXT, schema_name TEXT, table_name TEXT, initial_rows LONG, insert_rows LONG, update_rows LONG, delete_rows LONG, add_column LONG, drop_column LONG, rename_column LONG, create_table LONG, drop_table LONG, rename_table LONG, PRIMARY KEY(dst_alias, database_name, schema_name, table_name))";
 	private final String insertStatsTableSql = "INSERT OR REPLACE INTO table_statistics(dst_alias, database_name, schema_name, table_name, initial_rows, insert_rows, update_rows, delete_rows, add_column, drop_column, rename_column, create_table, drop_table, rename_table) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 	private final String updateStatsTableSql = "UPDATE table_statistics SET insert_rows = insert_rows + ?, update_rows = update_rows + ?, delete_rows = delete_rows + ?, add_column = add_column + ?, drop_column = drop_column + ?, rename_column = rename_column + ?, create_table = create_table + ?, drop_table = drop_table + ?, rename_table = rename_table + ? WHERE dst_alias = ? AND database_name = ? AND table_name = ?";
@@ -83,17 +83,17 @@ public class DeviceStatsCollector {
 		try (Connection statsFileConn = DriverManager.getConnection(url)) {
 			configureSqliteConnection(statsFileConn);
 			try (Statement stmt = statsFileConn.createStatement()) {
-				stmt.execute(createCheckpointTableSql);
-				try (ResultSet rs = stmt.executeQuery(selectCheckpointTableSql.replace("$", this.dstAlias))) {
+				stmt.execute(createDeviceStatisticsTableSql);
+				try (ResultSet rs = stmt.executeQuery(selectDeviceStatisticsTableSql.replace("$", this.dstAlias))) {
 					if (rs.next()) {
 						this.lastStatsCollectedLogSegmentSeqNum = rs.getLong(1);
 						this.hasInitializationStatsCollected = rs.getLong(2);
 						device.incrTotalProcessedLogSegmentCount(this.lastStatsCollectedLogSegmentSeqNum + 1);
 						device.incrTotalProcessedOperCount(rs.getLong(3));
 						device.incrTotalProcessedTxnCount(rs.getLong(4));
-						device.incrTotalProcessedLogSize(rs.getLong(5));			
+						device.incrTotalProcessedLogSize(rs.getLong(5));
 					} else {
-						String insertSql = insertCheckpointTableSql.replace("$", this.dstAlias);
+						String insertSql = insertDeviceStatisticsTableSql.replace("$", this.dstAlias);
 						stmt.execute(insertSql);
 						this.lastStatsCollectedLogSegmentSeqNum = -1;
 						this.hasInitializationStatsCollected = 0;
@@ -125,16 +125,16 @@ public class DeviceStatsCollector {
 		}
 		String statsUrl = "jdbc:sqlite:" + this.statsFilePath;
 		try (Connection statsFileConn = DriverManager.getConnection(statsUrl);
-				PreparedStatement updateLogSegmentCheckpointTablePstmt = statsFileConn.prepareStatement(updateLogSegmentCheckpointTableSql);
+				PreparedStatement updateLogSegmentDeviceStatisticsTablePstmt = statsFileConn.prepareStatement(updateLogSegmentDeviceStatisticsTableSql);
 				Statement statsStmt = statsFileConn.createStatement())
 		{
 			configureSqliteConnection(statsFileConn);
-			updateLogSegmentCheckpointTablePstmt.setLong(1, logSegmentSeqNumber);
-			updateLogSegmentCheckpointTablePstmt.setLong(2, operCount);
-			updateLogSegmentCheckpointTablePstmt.setLong(3, txnCount);
-			updateLogSegmentCheckpointTablePstmt.setLong(4, logSize);
-			updateLogSegmentCheckpointTablePstmt.setString(5, this.dstAlias);
-			updateLogSegmentCheckpointTablePstmt.execute();
+			updateLogSegmentDeviceStatisticsTablePstmt.setLong(1, logSegmentSeqNumber);
+			updateLogSegmentDeviceStatisticsTablePstmt.setLong(2, operCount);
+			updateLogSegmentDeviceStatisticsTablePstmt.setLong(3, txnCount);
+			updateLogSegmentDeviceStatisticsTablePstmt.setLong(4, logSize);
+			updateLogSegmentDeviceStatisticsTablePstmt.setString(5, this.dstAlias);
+			updateLogSegmentDeviceStatisticsTablePstmt.execute();
 			device.incrTotalProcessedLogSegmentCount(1);
 			device.incrTotalProcessedOperCount(operCount);
 			device.incrTotalProcessedTxnCount(txnCount);
@@ -154,7 +154,7 @@ public class DeviceStatsCollector {
 		try (Connection statsFileConn = DriverManager.getConnection(statsUrl);
 				PreparedStatement insertStatsTablePstmt = statsFileConn.prepareStatement(insertStatsTableSql);
 				PreparedStatement updateStatsTablePstmt = statsFileConn.prepareStatement(updateStatsTableSql);
-				PreparedStatement updateCDCLogSegmentCheckpointTablePstmt = statsFileConn.prepareStatement(updateLogSegmentCheckpointTableSql);
+				PreparedStatement updateCDCLogSegmentDeviceStatisticsTablePstmt = statsFileConn.prepareStatement(updateLogSegmentDeviceStatisticsTableSql);
 				Statement statsStmt = statsFileConn.createStatement()
 				) {			
 			configureSqliteConnection(statsFileConn);
@@ -263,12 +263,12 @@ public class DeviceStatsCollector {
 				updateStatsTablePstmt.executeBatch();
 			}
 
-			updateCDCLogSegmentCheckpointTablePstmt.setLong(1, logSegmentSeqNumber);
-			updateCDCLogSegmentCheckpointTablePstmt.setLong(2, totalOperCount);
-			updateCDCLogSegmentCheckpointTablePstmt.setLong(3, txnCount);
-			updateCDCLogSegmentCheckpointTablePstmt.setLong(4, logSize);
-			updateCDCLogSegmentCheckpointTablePstmt.setString(5, this.dstAlias);
-			updateCDCLogSegmentCheckpointTablePstmt.execute();
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.setLong(1, logSegmentSeqNumber);
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.setLong(2, totalOperCount);
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.setLong(3, txnCount);
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.setLong(4, logSize);
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.setString(5, this.dstAlias);
+			updateCDCLogSegmentDeviceStatisticsTablePstmt.execute();
 			statsFileConn.commit();
 			statsFileConn.setAutoCommit(true);
 			device.incrTotalProcessedLogSegmentCount(1);
@@ -356,7 +356,7 @@ public class DeviceStatsCollector {
 			if (insertBatchIsFilled) {
 				insertStatsTablePstmt.executeBatch();
 			}
-			String updateSql = updateInitializationStatsCheckpointTableSql.replace("$1", String.valueOf(totalInitializationRowCount));
+			String updateSql = updateInitializationStatsDeviceStatisticsTableSql.replace("$1", String.valueOf(totalInitializationRowCount));
 			updateSql = updateSql.replace("$2", String.valueOf(consolidatorControlPropMgr.getInitializedTables().entrySet().size()));
 			updateSql = updateSql.replace("$3", String.valueOf(totalInitializationSnapshotSize));
 			updateSql = updateSql.replace("$4", this.dstAlias);
@@ -388,7 +388,7 @@ public class DeviceStatsCollector {
 				Statement stmt = statsFileConn.createStatement()
 				) {			
 			configureSqliteConnection(statsFileConn);
-			String updateSql = updateInitializationStatsCheckpointTableSql.replace("$1", String.valueOf(operCount));
+			String updateSql = updateInitializationStatsDeviceStatisticsTableSql.replace("$1", String.valueOf(operCount));
 			updateSql = updateSql.replace("$2", String.valueOf(txnCount));
 			updateSql = updateSql.replace("$3", String.valueOf(size));
 			updateSql = updateSql.replace("$4", this.dstAlias);


### PR DESCRIPTION
# Fold per-device metadata into consolidator metadata; strip vestigial keys; rename `status` → `device_status`

## What this PR changes

### 1. Drop the dedicated `synclite_device_metadata.db` file
Device-scoped properties (`database_name`, `device_name`, `device_type`, `registered_time`, `detection_time`, `last_status_update_time`, `status_description`, `data_backup_snapshot`, status) are folded into the per-destination `consolidator_metadata` files that already existed. Writes fan out across all destinations so the value stays consistent; reads come from the first destination. The single-file `deviceMetadataMgr` field and its `getDeviceMetadataMgr()` accessor are removed, replaced by `upsertDeviceMetadataProperty` / `deleteDeviceMetadataProperty` / `getDeviceMetadataStringProperty` / `getDeviceMetadataLongProperty` on `Device`.

### 2. Strip vestigial `database_id` (`dbID`) and `allow_concurrent_writers`
Both fields had no remaining consumer. `Device.allowsConcurrentWriters()` is now a one-liner driven by `deviceType`: `false` for `SQLITE` / `SQLITE_STORE`, `true` otherwise. All path-builder signatures lose the `dbID` parameter.

### 3. Rename `"status"` → `"device_status"` in per-device metadata
Disambiguates from the `status` columns on the `device_status` and `device_statistics` SQL tables.

### Collateral fixes uncovered during the audit
- `Monitor.getInstance().incrResynchronizationCnt(this.dbID)` was passing the device id as a counter increment — corrected to `incrResynchronizationCnt(1)`.
- The persisted `checkpoint` table that `DeviceStatsCollector` owns is renamed to `device_statistics` (all SQL strings and prepared-statement variables renamed to match) — "checkpoint" was a misleading name for aggregate per-device statistics.
- `DeviceLogCleaner` reads/writes its `LAST_CLEANED_KEY` through the new `Device` helpers instead of poking `deviceMetadataMgr` directly.
- Status parsing now tolerates an unknown enum value by falling back to `UNREGISTERED` instead of throwing `IllegalArgumentException`.

## Changed files

| File | Change |
| --- | --- |
| `root/core/src/main/java/com/synclite/consolidator/device/Device.java` | <ul><li>Remove `private long dbID;`, `private int allowsConcurrentWriters;`, `private MetadataManager deviceMetadataMgr;` fields and the `getDeviceMetadataMgr()` accessor.</li><li>Add `upsertDeviceMetadataProperty` / `deleteDeviceMetadataProperty` / `getDeviceMetadataStringProperty` / `getDeviceMetadataLongProperty` helpers that fan out across `consolidatorMetadataMgrs`.</li><li>Rename `initializeDeviceMetadataFile()` → `initializeDeviceMetadata()` and stop opening a separate device-metadata SQLite file.</li><li>Simplify `allowsConcurrentWriters()` to a `switch` on `deviceType`.</li><li>Drop registration-time reads/writes of `allow_concurrent_writers` and `database_id`; drop `identity.put("database_id", ...)`.</li><li>Rename metadata key `status` → `device_status` at both read and write sites; tolerate unknown enum values.</li><li>Strip `this.dbID` from 8 path-builder call sites.</li><li>Fix `incrResynchronizationCnt(this.dbID)` → `incrResynchronizationCnt(1)`.</li><li>Error strings updated from "replicator metadata file" → "consolidator metadata".</li></ul> |
| `root/core/src/main/java/com/synclite/consolidator/global/SyncLiteDeviceInfo.java` | Drop the `dbID` parameter from `getCDCLogSegmentPath`. Remove the now-unused `getMetadataFileName()` (which returned `"synclite_device_metadata.db"`). |
| `root/core/src/main/java/com/synclite/consolidator/global/SyncLiteLoggerInfo.java` | Drop the `dbID` parameter from `getCommandLogSegmentPath` and `getEventLogSegmentPath`. |
| `root/core/src/main/java/com/synclite/consolidator/processor/DeviceLogCleaner.java` | Read/write `LAST_CLEANED_KEY` through `Device.getDeviceMetadataLongProperty` / `Device.upsertDeviceMetadataProperty` instead of poking `deviceMetadataMgr`. Update inline doc comment to point at the consolidator metadata DB. |
| `root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java` | Rename the persisted `checkpoint` table and all associated SQL strings and prepared-statement variables to `device_statistics` (`createDeviceStatisticsTableSql`, `insertDeviceStatisticsTableSql`, `selectDeviceStatisticsTableSql`, `updateLogSegmentDeviceStatisticsTableSql`, `updateInitializationStatsDeviceStatisticsTableSql`, etc.). |

## Compatibility notes

- **On-disk format change.** Existing deployments still have a separate `synclite_device_metadata.db` file on disk; the new code does not read it. A `status` key in the old file is also obsolete — the new key is `device_status` inside the consolidator metadata file. If preserving historical state across the upgrade matters, run a one-shot migration before redeploying (copy keys from the old file into each per-destination consolidator metadata DB, renaming `status` → `device_status`).
- **API change.** `Device.getDeviceMetadataMgr()` is removed. Any external code (e.g., test fixtures) that grabbed the `MetadataManager` directly must switch to the new `*DeviceMetadataProperty` helpers.
- **Path-builder signatures lost `dbID`.** Downstream code linking those helpers must be recompiled against the new signatures.
- **Persisted `checkpoint` table rename.** First startup against an existing destination database that holds the old `checkpoint` table will create a fresh `device_statistics` table (`CREATE TABLE IF NOT EXISTS`); existing rows in `checkpoint` will be orphaned and per-device stats will reset to zero. Run `ALTER TABLE checkpoint RENAME TO device_statistics` manually before redeploy if you need to preserve aggregates.
