### PR TITLE
Hardens restart recovery and metadata bootstrap

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/global/ConfLoader.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConfLoader.java
@@ -296,6 +296,9 @@ public class ConfLoader {
 	}
 	
 	public boolean isAllowedTable(int dstIndex, String tableName) {
+		if (SyncLiteConsolidatorInfo.isSystemMetadataTable(tableName)) {
+			return true;
+		}
 		if (dstTableFilterMapperRules == null) {
 			return true;
 		}
@@ -328,6 +331,9 @@ public class ConfLoader {
 	}
 
 	public String getMappedTableName(int dstIndex, String tableName) {
+		if (SyncLiteConsolidatorInfo.isSystemMetadataTable(tableName)) {
+			return tableName;
+		}
 		if (dstTableFilterMapperRules == null) {
 			return tableName;
 		}
@@ -357,6 +363,9 @@ public class ConfLoader {
 	}
 
 	public boolean isAllowedColumn(int dstIndex, String tableName, String columnName) {
+		if (SyncLiteConsolidatorInfo.isSystemMetadataTable(tableName)) {
+			return true;
+		}
 		if (dstColumnFilterMapperRules == null) {
 			return true;
 		}
@@ -396,6 +405,9 @@ public class ConfLoader {
 	}
 
 	public String getMappedColumnName(int dstIndex, String tableName, String columnName) {		
+		if (SyncLiteConsolidatorInfo.isSystemMetadataTable(tableName)) {
+			return columnName;
+		}
 		if (dstColumnFilterMapperRules == null) {
 			return columnName;
 		}
@@ -2810,8 +2822,10 @@ public class ConfLoader {
 				}
 				line = reader.readLine();
 			}
-			//Always allow synclite_checkpoint table
+			//Always allow consolidator-owned system metadata tables
 			this.dstTableFilterMapperRules[dstIndex].put(SyncLiteConsolidatorInfo.getSyncLiteCheckpointTableName().toUpperCase(), "true");
+			this.dstTableFilterMapperRules[dstIndex].put(SyncLiteConsolidatorInfo.getConsolidatorTableMetadataTableName().toUpperCase(), "true");
+			this.dstTableFilterMapperRules[dstIndex].put(SyncLiteConsolidatorInfo.getConsolidatorMetadataTableName().toUpperCase(), "true");
 		} catch (IOException e) {
 			throw new SyncLitePropsException("Failed to load configuration file : " + filterMapperRulesFile + " : ", e);
 		} finally {

--- a/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
@@ -36,10 +36,15 @@ import com.synclite.consolidator.connector.JDBCConnector;
 import com.synclite.consolidator.device.Device;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
+import com.synclite.consolidator.oper.CreateTable;
+import com.synclite.consolidator.oper.Delete;
+import com.synclite.consolidator.oper.Insert;
+import com.synclite.consolidator.processor.SQLExecutor;
 import com.synclite.consolidator.schema.Column;
 import com.synclite.consolidator.schema.ConsolidatorSrcTable;
 import com.synclite.consolidator.schema.DataType;
 import com.synclite.consolidator.schema.TableID;
+import com.synclite.consolidator.schema.TableMapper;
 import com.synclite.consolidator.watchdog.Monitor;
 
 public class ConsolidatorMetadataManager extends MetadataManager {
@@ -59,23 +64,21 @@ public class ConsolidatorMetadataManager extends MetadataManager {
     private long initializationCount;
     private volatile long lastConsolidatedCDCLogSegmentSeqNumber = -1;
     private int dstIndex;
-
-    private static final String createDstMetadataTblSql =
-            "CREATE TABLE IF NOT EXISTS synclite_consolidator_metadata(" +
-            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, " +
-            "prop_key VARCHAR(255) NOT NULL, prop_value TEXT, " +
-            "PRIMARY KEY(device_uuid, device_name, prop_key))";
-
-    private static final String createDstTableMetadataTblSql =
-            "CREATE TABLE IF NOT EXISTS synclite_consolidator_table_metadata(" +
-            "device_uuid VARCHAR(64) NOT NULL, device_name VARCHAR(255) NOT NULL, " +
-            "database_name VARCHAR(255) NOT NULL, table_name VARCHAR(255) NOT NULL, prop_key VARCHAR(255) NOT NULL, prop_value TEXT, " +
-            "PRIMARY KEY(device_uuid, device_name, database_name, table_name, prop_key))";
+        private final TableMapper systemTableMapper;
+        private final ConsolidatorSrcTable dstMetadataSystemTable;
+        private final ConsolidatorSrcTable dstTableMetadataSystemTable;
 
     protected ConsolidatorMetadataManager(Path metadataFilePath, Device device, int dstIndex) throws SQLException {
         super(metadataFilePath);
         this.device = device;
         this.dstIndex = dstIndex;
+        try {
+            this.systemTableMapper = TableMapper.getSystemTableMapperInstance(dstIndex);
+        } catch (SyncLiteException e) {
+            throw new SQLException("Failed to initialize system table mapper", e);
+        }
+        this.dstMetadataSystemTable = SyncLiteConsolidatorInfo.getConsolidatorMetadataTableSchema(device.getDeviceUUID(), device.getDeviceName(), dstIndex);
+        this.dstTableMetadataSystemTable = SyncLiteConsolidatorInfo.getConsolidatorTableMetadataTableSchema(device.getDeviceUUID(), device.getDeviceName(), dstIndex);
         initializeSchemaTable();        
     }
 
@@ -101,10 +104,26 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             }
             return null;
         }
-        // DESTINATION mode: read from destination
+        // DESTINATION mode: read from destination using a single autoCommit=true
+        // connection to avoid the two-connection DDL-lock deadlock.
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            ensureDstTableMetadataTable(conn);
-            String sql = "SELECT prop_value FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND database_name = ? AND table_name = ? AND prop_key = ?";
+            conn.setAutoCommit(true);
+            String tblMetaTbl = qualifiedDstTableName("synclite_consolidator_table_metadata");
+            if (!dstTableMetadataTableEnsured) {
+                try (Statement ddl = conn.createStatement()) {
+                    ddl.execute("CREATE TABLE IF NOT EXISTS " + tblMetaTbl
+                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
+                            + " synclite_device_name VARCHAR(255) NOT NULL,"
+                            + " synclite_update_timestamp TEXT,"
+                            + " database_name VARCHAR(255) NOT NULL,"
+                            + " table_name VARCHAR(255) NOT NULL,"
+                            + " prop_key VARCHAR(255) NOT NULL,"
+                            + " prop_value TEXT,"
+                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, database_name, table_name, prop_key))");
+                }
+                dstTableMetadataTableEnsured = true;
+            }
+            String sql = "SELECT prop_value FROM " + tblMetaTbl + " WHERE synclite_device_id = ? AND synclite_device_name = ? AND database_name = ? AND table_name = ? AND prop_key = ?";
             try (PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
@@ -133,18 +152,15 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             return;
         }
         // DESTINATION mode: delete from destination table
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstTableMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement stmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ?")) {
-                stmt.setString(1, this.device.getDeviceUUID());
-                stmt.setString(2, this.device.getDeviceName());
-                stmt.execute();
-            }
-            conn.commit();
-        } catch (DstExecutionException e) {
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstTableMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
+            Delete deleteAll = new Delete(dstTableMetadataSystemTable, new ArrayList<Object>());
+            deleteAll.whereColumns = new ArrayList<Column>();
+            dstExecutor.execute(systemTableMapper.mapOper(deleteAll));
+            dstExecutor.commitTran();
+        } catch (SyncLiteException e) {
             throw new SQLException("Failed to connect to destination to delete table metadata", e);
         }
     }
@@ -158,18 +174,18 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             }
         } else {
             // DESTINATION mode: delete create_sql rows from unified table_metadata
-            try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-                conn.setAutoCommit(false);
-                ensureDstTableMetadataTable(conn);
-                seedDstMetadataVersionIfAbsent(conn);
-                try (PreparedStatement stmt = conn.prepareStatement(
-                        "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = 'create_sql'")) {
-                    stmt.setString(1, this.device.getDeviceUUID());
-                    stmt.setString(2, this.device.getDeviceName());
-                    stmt.execute();
-                }
-                conn.commit();
-            } catch (DstExecutionException e) {
+            try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+                dstExecutor.beginTran();
+                ensureDstTableMetadataTable(dstExecutor);
+                seedDstMetadataVersionIfAbsent(dstExecutor);
+                ArrayList<Object> beforeValues = new ArrayList<Object>(1);
+                beforeValues.add(SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+                Delete deleteSchemaRows = new Delete(dstTableMetadataSystemTable, beforeValues);
+                deleteSchemaRows.whereColumns = new ArrayList<Column>();
+                deleteSchemaRows.whereColumns.add(dstTableMetadataSystemTable.colMap.get("prop_key"));
+                dstExecutor.execute(systemTableMapper.mapOper(deleteSchemaRows));
+                dstExecutor.commitTran();
+            } catch (SyncLiteException e) {
                 throw new SQLException("Failed to connect to destination to delete schema info", e);
             }
         }
@@ -199,31 +215,30 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             return;
         }
         // DESTINATION mode: write to destination
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstTableMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND database_name = ? AND table_name = ? AND prop_key = ?");
-                 PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_table_metadata(device_uuid, device_name, database_name, table_name, prop_key, prop_value) VALUES(?, ?, ?, ?, ?, ?)")) {
-                deleteStmt.setString(1, this.device.getDeviceUUID());
-                deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setString(3, srcTable.id.database);
-                deleteStmt.setString(4, srcTable.id.table);
-                deleteStmt.setString(5, key);
-                deleteStmt.execute();
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstTableMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
 
-                insertStmt.setString(1, this.device.getDeviceUUID());
-                insertStmt.setString(2, this.device.getDeviceName());
-                insertStmt.setString(3, srcTable.id.database);
-                insertStmt.setString(4, srcTable.id.table);
-                insertStmt.setString(5, key);
-                insertStmt.setString(6, value == null ? null : value.toString());
-                insertStmt.execute();
-            }
-            conn.commit();
-        } catch (DstExecutionException e) {
+            ArrayList<Object> beforeValues = new ArrayList<Object>(3);
+            beforeValues.add(srcTable.id.database);
+            beforeValues.add(srcTable.id.table);
+            beforeValues.add(key);
+            Delete deleteEntry = new Delete(dstTableMetadataSystemTable, beforeValues);
+            deleteEntry.whereColumns = new ArrayList<Column>();
+            deleteEntry.whereColumns.add(dstTableMetadataSystemTable.colMap.get("database_name"));
+            deleteEntry.whereColumns.add(dstTableMetadataSystemTable.colMap.get("table_name"));
+            deleteEntry.whereColumns.add(dstTableMetadataSystemTable.colMap.get("prop_key"));
+            dstExecutor.execute(systemTableMapper.mapOper(deleteEntry));
+
+            ArrayList<Object> afterValues = new ArrayList<Object>(4);
+            afterValues.add(srcTable.id.database);
+            afterValues.add(srcTable.id.table);
+            afterValues.add(key);
+            afterValues.add(value == null ? null : value.toString());
+            dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstTableMetadataSystemTable, afterValues, false)));
+            dstExecutor.commitTran();
+        } catch (SyncLiteException e) {
             throw new SQLException("Failed to connect to destination for table metadata persistence", e);
         }
     }
@@ -254,11 +269,63 @@ public class ConsolidatorMetadataManager extends MetadataManager {
                     }
                     insertSchemaStmt.executeBatch();
                 }
+
+                // Keep local mode aligned with DESTINATION mode schema persistence:
+                // store source CREATE SQL in table_metadata(key='create_sql').
+                String createSql = buildCreateSqlFromColumns(srcTable);
+                try (PreparedStatement deleteStmt = conn.prepareStatement(deleteTableMetadataTblSql)) {
+                    deleteStmt.setString(1, srcTable.id.database);
+                    deleteStmt.setString(2, srcTable.id.table);
+                    deleteStmt.setString(3, SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+                    deleteStmt.execute();
+                }
+                try (PreparedStatement insertStmt = conn.prepareStatement(insertTableMetadataTblSql)) {
+                    insertStmt.setString(1, srcTable.id.database);
+                    insertStmt.setString(2, srcTable.id.schema);
+                    insertStmt.setString(3, srcTable.id.table);
+                    insertStmt.setString(4, SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+                    insertStmt.setString(5, createSql);
+                    insertStmt.execute();
+                }
                 conn.commit();
             }
         }
         // In DESTINATION mode: actual schema persistence to destination is done by DeviceSyncProcessor.persistSchemaToDst()
         this.deviceSrcTables.put(srcTable.id, srcTable);
+    }
+
+    private String buildCreateSqlFromColumns(ConsolidatorSrcTable srcTable) {
+        StringBuilder sb = new StringBuilder("CREATE TABLE IF NOT EXISTS ").append(srcTable.id.table).append(" (");
+        ArrayList<Column> pkCols = new ArrayList<Column>();
+        boolean first = true;
+        for (Column col : srcTable.columns) {
+            if (!first) {
+                sb.append(", ");
+            }
+            sb.append(col.column).append(" ").append(col.type.dbNativeDataType);
+            if (col.isNotNull != 0) {
+                sb.append(" NOT NULL");
+            }
+            if (col.pkIndex != 0) {
+                pkCols.add(col);
+            }
+            first = false;
+        }
+        if (pkCols.size() == 1) {
+            sb.append(", PRIMARY KEY(").append(pkCols.get(0).column).append(")");
+        } else if (pkCols.size() > 1) {
+            pkCols.sort((a, b) -> Integer.compare(a.pkIndex, b.pkIndex));
+            sb.append(", PRIMARY KEY(");
+            for (int i = 0; i < pkCols.size(); ++i) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(pkCols.get(i).column);
+            }
+            sb.append(")");
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
     
@@ -288,23 +355,33 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             // which calls upsertSchema() to populate the in-memory cache. Nothing to do here.
             return;
         }
-    	this.deviceSrcTables.clear();
+	this.deviceSrcTables.clear();
+        String sql = "SELECT database_name, table_name, value FROM table_metadata WHERE key = '" + SyncLiteConsolidatorInfo.getCreateSqlPropKey() + "' ORDER BY database_name, table_name";
         try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + metadataFilePath)) {
             try (Statement stmt = conn.createStatement()) {
-                try (ResultSet rs = stmt.executeQuery(selectSchemaTblSql)) {
-                    TableID currentTableID = null;
-                    ConsolidatorSrcTable currentTable = null;
-                    while (rs.next()) {
-                        TableID tableID = TableID.from(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex, rs.getString(1), rs.getString(2), rs.getString(3));
-                        if (!tableID.equals(currentTableID)) {
-                            currentTableID = tableID;
-                            currentTable = ConsolidatorSrcTable.from(currentTableID);
-                            this.deviceSrcTables.put(tableID, currentTable);
+                try (ResultSet rs = stmt.executeQuery(sql)) {
+                    try (Connection schemaConn = DriverManager.getConnection("jdbc:sqlite::memory:")) {
+                        while (rs.next()) {
+                            String dbName = rs.getString(1);
+                            String tableName = rs.getString(2);
+                            String createSql = rs.getString(3);
+                            if (createSql == null || createSql.isBlank()) {
+                                continue;
+                            }
+                            try (Statement schemaStmt = schemaConn.createStatement()) {
+                                schemaStmt.execute(createSql);
+                            }
+                            TableID tableID = TableID.from(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex, dbName, null, tableName);
+                            ConsolidatorSrcTable currentTable = ConsolidatorSrcTable.from(tableID);
+                            currentTable.sql = createSql;
                             currentTable.clearColumns();
+                            for (Column c : device.schemaReader.fetchColumns(schemaConn, tableID)) {
+                                currentTable.addColumn(c);
+                            }
+                            this.deviceSrcTables.put(tableID, currentTable);
                         }
-                        DataType dataType = new DataType(rs.getString(6), device.schemaReader.getJavaSqlType(rs.getString(6)), device.schemaReader.getStorageClass(rs.getString(6)));
-                        Column c = new Column(rs.getLong(4), rs.getString(5), dataType, rs.getInt(7), rs.getString(8), rs.getInt(9), rs.getInt(10));
-                        currentTable.addColumn(c);
+                    } catch (SyncLiteException e) {
+                        throw new SQLException("Failed to load schema columns from local create_sql metadata", e);
                     }
                 }
             }
@@ -334,58 +411,72 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         return JDBCConnector.getInstance(dstIndex).isJdbcCapable();
     }
 
-    private void ensureDstMetadataTable(Connection conn) throws SQLException {
-        try (Statement stmt = conn.createStatement()) {
-            stmt.execute(createDstMetadataTblSql);
+    private volatile boolean dstMetadataTableEnsured = false;
+    private volatile boolean dstTableMetadataTableEnsured = false;
+
+    private void ensureDstMetadataTable(SQLExecutor dstExecutor) throws DstExecutionException {
+        if (dstMetadataTableEnsured) {
+            return;
         }
+        device.tracer.debug("[BOOT] Ensuring consolidator metadata table exists on destination");
+        dstExecutor.execute(systemTableMapper.mapOper(new CreateTable(dstMetadataSystemTable)));
+        dstMetadataTableEnsured = true;
+        device.tracer.debug("[BOOT] Consolidator metadata table ensured on destination");
     }
 
     private volatile boolean dstVersionSeeded = false;
 
     /**
      * Seed the {@code synclite_metadata_version} row inline on the caller's connection.
-     * Must be called on a writer path: the caller's subsequent {@code commit()} makes the
-     * insert durable. Opening a second pool connection here would deadlock against the
-     * caller's open transaction on the same SQLite file (SQLITE_BUSY).
+     * Uses DELETE+INSERT on the same dstExecutor transaction to avoid a separate
+     * SELECT connection which would deadlock on PostgreSQL: the dstExecutor holds an
+     * open AccessExclusiveLock from the preceding CREATE TABLE, and a SELECT on a
+     * second autoCommit=false connection from the same pool waits indefinitely.
      */
-    private void seedDstMetadataVersionIfAbsent(Connection conn) throws SQLException {
+    private void seedDstMetadataVersionIfAbsent(SQLExecutor dstExecutor) throws SQLException, SyncLiteException {
         if (dstVersionSeeded) {
+            device.tracer.debug("[BOOT] Metadata version already seeded, skipping");
             return;
         }
-        // The seed targets synclite_consolidator_metadata; ensure that table exists
-        // regardless of which writer path (property vs. table-metadata) reached us first.
-        try (Statement stmt = conn.createStatement()) {
-            stmt.execute(createDstMetadataTblSql);
-        }
-        try (PreparedStatement sel = conn.prepareStatement(
-                "SELECT 1 FROM synclite_consolidator_metadata "
-                + "WHERE device_uuid = ? AND device_name = ? AND prop_key = ?")) {
-            sel.setString(1, this.device.getDeviceUUID());
-            sel.setString(2, this.device.getDeviceName());
-            sel.setString(3, SYNCLITE_METADATA_VERSION_KEY);
-            try (ResultSet rs = sel.executeQuery()) {
-                if (rs.next()) {
-                    dstVersionSeeded = true;
-                    return;
-                }
-            }
-        }
-        try (PreparedStatement ins = conn.prepareStatement(
-                "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) "
-                + "VALUES(?, ?, ?, ?)")) {
-            ins.setString(1, this.device.getDeviceUUID());
-            ins.setString(2, this.device.getDeviceName());
-            ins.setString(3, SYNCLITE_METADATA_VERSION_KEY);
-            ins.setString(4, Long.toString(SYNCLITE_METADATA_VERSION));
-            ins.execute();
-        }
+        device.tracer.debug("[BOOT] Seeding destination metadata version");
+        ensureDstMetadataTable(dstExecutor);
+        // Delete-then-insert (idempotent) on the same transaction to avoid opening
+        // a second connection for a SELECT check.
+        ArrayList<Object> delVals = new ArrayList<Object>(1);
+        delVals.add(SYNCLITE_METADATA_VERSION_KEY);
+        Delete deleteProp = new Delete(dstMetadataSystemTable, delVals);
+        deleteProp.whereColumns = new ArrayList<Column>();
+        deleteProp.whereColumns.add(dstMetadataSystemTable.colMap.get("prop_key"));
+        dstExecutor.execute(systemTableMapper.mapOper(deleteProp));
+        ArrayList<Object> vals = new ArrayList<Object>(2);
+        vals.add(SYNCLITE_METADATA_VERSION_KEY);
+        vals.add(Long.toString(SYNCLITE_METADATA_VERSION));
+        dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstMetadataSystemTable, vals, false)));
         dstVersionSeeded = true;
+        device.tracer.info("[BOOT] Destination metadata version seeded successfully");
     }
 
-    private void ensureDstTableMetadataTable(Connection conn) throws SQLException {
-        try (Statement stmt = conn.createStatement()) {
-            stmt.execute(createDstTableMetadataTblSql);
+    private void ensureDstTableMetadataTable(SQLExecutor dstExecutor) throws DstExecutionException {
+        if (dstTableMetadataTableEnsured) {
+            return;
         }
+        dstExecutor.execute(systemTableMapper.mapOper(new CreateTable(dstTableMetadataSystemTable)));
+        dstTableMetadataTableEnsured = true;
+    }
+
+    /**
+     * Returns a schema-qualified reference to a destination system metadata table name
+     * (e.g. "myschema"."synclite_consolidator_metadata") when dst-schema is configured,
+     * or the bare name when no schema is configured. Used for raw JDBC SQL strings that
+     * bypass the system table mapper so PostgreSQL resolves them in the right schema
+     * instead of following search_path (which defaults to public).
+     */
+    private String qualifiedDstTableName(String tableName) {
+        String schema = ConfLoader.getInstance().getDstSchema(dstIndex);
+        if (schema != null && !schema.trim().isEmpty()) {
+            return "\"" + schema.replace("\"", "\"\"") + "\".\"" + tableName.replace("\"", "\"\"") + "\"";
+        }
+        return tableName;
     }
 
     @Override
@@ -394,64 +485,91 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             super.upsertProperties(values);
             return;
         }
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?");
-                 PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) VALUES(?, ?, ?, ?)")) {
-                for (Map.Entry<String, Object> entry : values.entrySet()) {
-                    String val = entry.getValue() == null ? null : entry.getValue().toString();
-                    deleteStmt.setString(1, this.device.getDeviceUUID());
-                    deleteStmt.setString(2, this.device.getDeviceName());
-                    deleteStmt.setString(3, entry.getKey());
-                    deleteStmt.addBatch();
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
+            for (Map.Entry<String, Object> entry : values.entrySet()) {
+                ArrayList<Object> beforeValues = new ArrayList<Object>(1);
+                beforeValues.add(entry.getKey());
+                Delete deleteProp = new Delete(dstMetadataSystemTable, beforeValues);
+                deleteProp.whereColumns = new ArrayList<Column>();
+                deleteProp.whereColumns.add(dstMetadataSystemTable.colMap.get("prop_key"));
+                dstExecutor.execute(systemTableMapper.mapOper(deleteProp));
 
-                    insertStmt.setString(1, this.device.getDeviceUUID());
-                    insertStmt.setString(2, this.device.getDeviceName());
-                    insertStmt.setString(3, entry.getKey());
-                    insertStmt.setString(4, val);
-                    insertStmt.addBatch();
-                }
-                deleteStmt.executeBatch();
-                insertStmt.executeBatch();
+                ArrayList<Object> afterValues = new ArrayList<Object>(2);
+                afterValues.add(entry.getKey());
+                afterValues.add(entry.getValue() == null ? null : entry.getValue().toString());
+                dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstMetadataSystemTable, afterValues, false)));
             }
-            conn.commit();
-        } catch (DstExecutionException e) {
+            dstExecutor.commitTran();
+        } catch (SyncLiteException e) {
             throw new SQLException("Failed to connect to destination for consolidator metadata persistence", e);
         }
     }
 
+    /**
+     * Boot-time: Insert device metadata property if absent (called once per device boot).
+     */
+    public void insertPropertyIfAbsent(String key, Object value) throws SQLException {
+        if (!isDestinationMetadataMode()) {
+            super.upsertProperty(key, value);
+            return;
+        }
+
+        // Fast read path to avoid unnecessary transaction churn when property already exists.
+        if (getStringProperty(key) != null) {
+            device.tracer.debug("[BOOT] Device metadata property already exists: " + key);
+            return;
+        }
+
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
+
+            ArrayList<Object> afterValues = new ArrayList<Object>(2);
+            afterValues.add(key);
+            afterValues.add(value == null ? null : value.toString());
+            dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstMetadataSystemTable, afterValues, false)));
+
+            dstExecutor.commitTran();
+            device.tracer.info("[BOOT] Device metadata property inserted: " + key + "=" + value);
+        } catch (SyncLiteException e) {
+            throw new SQLException("Failed to insert device metadata property at boot", e);
+        }
+    }
+
+    /**
+     * Runtime: upsert device metadata property (during segment apply).
+     */
     @Override
     public void upsertProperty(String key, Object value) throws SQLException {
         if (!isDestinationMetadataMode()) {
             super.upsertProperty(key, value);
             return;
         }
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?");
-                 PreparedStatement insertStmt = conn.prepareStatement(
-                    "INSERT INTO synclite_consolidator_metadata(device_uuid, device_name, prop_key, prop_value) VALUES(?, ?, ?, ?)")) {
-                deleteStmt.setString(1, this.device.getDeviceUUID());
-                deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setString(3, key);
-                deleteStmt.execute();
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
 
-                insertStmt.setString(1, this.device.getDeviceUUID());
-                insertStmt.setString(2, this.device.getDeviceName());
-                insertStmt.setString(3, key);
-                insertStmt.setString(4, value == null ? null : value.toString());
-                insertStmt.execute();
-            }
-            conn.commit();
-        } catch (DstExecutionException e) {
-            throw new SQLException("Failed to connect to destination for consolidator metadata persistence", e);
+            ArrayList<Object> beforeValues = new ArrayList<Object>(1);
+            beforeValues.add(key);
+            Delete deleteProp = new Delete(dstMetadataSystemTable, beforeValues);
+            deleteProp.whereColumns = new ArrayList<Column>();
+            deleteProp.whereColumns.add(dstMetadataSystemTable.colMap.get("prop_key"));
+            dstExecutor.execute(systemTableMapper.mapOper(deleteProp));
+
+            ArrayList<Object> afterValues = new ArrayList<Object>(2);
+            afterValues.add(key);
+            afterValues.add(value == null ? null : value.toString());
+            dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstMetadataSystemTable, afterValues, false)));
+
+            dstExecutor.commitTran();
+            device.tracer.debug("[RUNTIME] Device metadata property upserted: " + key + "=" + value);
+        } catch (SyncLiteException e) {
+            throw new SQLException("Failed to update device metadata property", e);
         }
     }
 
@@ -461,19 +579,19 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             super.deleteProperty(key);
             return;
         }
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement deleteStmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?")) {
-                deleteStmt.setString(1, this.device.getDeviceUUID());
-                deleteStmt.setString(2, this.device.getDeviceName());
-                deleteStmt.setString(3, key);
-                deleteStmt.execute();
-            }
-            conn.commit();
-        } catch (DstExecutionException e) {
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
+
+            ArrayList<Object> beforeValues = new ArrayList<Object>(1);
+            beforeValues.add(key);
+            Delete deleteProp = new Delete(dstMetadataSystemTable, beforeValues);
+            deleteProp.whereColumns = new ArrayList<Column>();
+            deleteProp.whereColumns.add(dstMetadataSystemTable.colMap.get("prop_key"));
+            dstExecutor.execute(systemTableMapper.mapOper(deleteProp));
+            dstExecutor.commitTran();
+        } catch (SyncLiteException e) {
             throw new SQLException("Failed to connect to destination for consolidator metadata persistence", e);
         }
     }
@@ -483,9 +601,27 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         if (!isDestinationMetadataMode()) {
             return super.getStringProperty(key);
         }
+        // Use a single autoCommit=true connection so that:
+        // (a) the bootstrap CREATE TABLE IF NOT EXISTS commits immediately, and
+        // (b) the subsequent SELECT does not wait for the DDL's AccessExclusiveLock
+        //     (which would deadlock when DDL and SELECT are on separate autoCommit=false
+        //     connections from the same HikariCP pool on the same thread).
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            ensureDstMetadataTable(conn);
-            String sql = "SELECT prop_value FROM synclite_consolidator_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = ?";
+            conn.setAutoCommit(true);
+            String metaTbl = qualifiedDstTableName("synclite_consolidator_metadata");
+            if (!dstMetadataTableEnsured) {
+                try (Statement ddl = conn.createStatement()) {
+                    ddl.execute("CREATE TABLE IF NOT EXISTS " + metaTbl
+                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
+                            + " synclite_device_name VARCHAR(255) NOT NULL,"
+                            + " synclite_update_timestamp TEXT,"
+                            + " prop_key VARCHAR(255) NOT NULL,"
+                            + " prop_value TEXT,"
+                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, prop_key))");
+                }
+                dstMetadataTableEnsured = true;
+            }
+            String sql = "SELECT prop_value FROM " + metaTbl + " WHERE synclite_device_id = ? AND synclite_device_name = ? AND prop_key = ?";
             try (PreparedStatement stmt = conn.prepareStatement(sql)) {
                 stmt.setString(1, this.device.getDeviceUUID());
                 stmt.setString(2, this.device.getDeviceName());
@@ -519,18 +655,18 @@ public class ConsolidatorMetadataManager extends MetadataManager {
                 }
             }
         } else {
-            try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-                conn.setAutoCommit(false);
-                ensureDstTableMetadataTable(conn);
-                seedDstMetadataVersionIfAbsent(conn);
-                try (PreparedStatement stmt = conn.prepareStatement(
-                        "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ? AND prop_key = 'create_sql'")) {
-                    stmt.setString(1, this.device.getDeviceUUID());
-                    stmt.setString(2, this.device.getDeviceName());
-                    stmt.execute();
-                }
-                conn.commit();
-            } catch (DstExecutionException e) {
+            try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+                dstExecutor.beginTran();
+                ensureDstTableMetadataTable(dstExecutor);
+                seedDstMetadataVersionIfAbsent(dstExecutor);
+                ArrayList<Object> beforeValues = new ArrayList<Object>(1);
+                beforeValues.add(SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+                Delete deleteSchemaRows = new Delete(dstTableMetadataSystemTable, beforeValues);
+                deleteSchemaRows.whereColumns = new ArrayList<Column>();
+                deleteSchemaRows.whereColumns.add(dstTableMetadataSystemTable.colMap.get("prop_key"));
+                dstExecutor.execute(systemTableMapper.mapOper(deleteSchemaRows));
+                dstExecutor.commitTran();
+            } catch (SyncLiteException e) {
                 throw new SQLException("Failed to connect to destination to reset schemas", e);
             }
         }
@@ -546,18 +682,15 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             }
             return;
         }
-        try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
-            conn.setAutoCommit(false);
-            ensureDstTableMetadataTable(conn);
-            seedDstMetadataVersionIfAbsent(conn);
-            try (PreparedStatement stmt = conn.prepareStatement(
-                    "DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = ? AND device_name = ?")) {
-                stmt.setString(1, this.device.getDeviceUUID());
-                stmt.setString(2, this.device.getDeviceName());
-                stmt.execute();
-            }
-            conn.commit();
-        } catch (DstExecutionException e) {
+        try (SQLExecutor dstExecutor = SQLExecutor.getInstance(device, dstIndex, device.tracer)) {
+            dstExecutor.beginTran();
+            ensureDstTableMetadataTable(dstExecutor);
+            seedDstMetadataVersionIfAbsent(dstExecutor);
+            Delete deleteAll = new Delete(dstTableMetadataSystemTable, new ArrayList<Object>());
+            deleteAll.whereColumns = new ArrayList<Column>();
+            dstExecutor.execute(systemTableMapper.mapOper(deleteAll));
+            dstExecutor.commitTran();
+        } catch (SyncLiteException e) {
             throw new SQLException("Failed to connect to destination to reset table metadata", e);
         }
     }
@@ -623,6 +756,58 @@ public class ConsolidatorMetadataManager extends MetadataManager {
     }
 
     public final void initializeConsolidatorMetadataFile() throws SyncLiteException {
+        // For DESTINATION metadata mode, create both system metadata tables and commit
+        // them upfront before any property reads open a second connection from the pool.
+        // We use a plain autoCommit JDBC connection here instead of SQLExecutor so that:
+        // (a) the DDL commits immediately on the same connection, and
+        // (b) we avoid SQLExecutor construction overhead during Device.<init> which can
+        //     cause connection pool timeouts before the device is registered.
+        if (isDestinationMetadataMode()) {
+            try (Connection ddlConn = JDBCConnector.getInstance(dstIndex).connect()) {
+                ddlConn.setAutoCommit(true);
+                try (Statement ddlStmt = ddlConn.createStatement()) {
+                    // Build schema-qualified CREATE TABLE IF NOT EXISTS SQL directly so
+                    // PostgreSQL creates the tables in the configured schema, not search_path.
+                    String metaTbl = qualifiedDstTableName("synclite_consolidator_metadata");
+                    String tblMetaTbl = qualifiedDstTableName("synclite_consolidator_table_metadata");
+                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + metaTbl
+                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
+                            + " synclite_device_name VARCHAR(255) NOT NULL,"
+                            + " synclite_update_timestamp TEXT,"
+                            + " prop_key VARCHAR(255) NOT NULL,"
+                            + " prop_value TEXT,"
+                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, prop_key))");
+                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + tblMetaTbl
+                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
+                            + " synclite_device_name VARCHAR(255) NOT NULL,"
+                            + " synclite_update_timestamp TEXT,"
+                            + " database_name VARCHAR(255) NOT NULL,"
+                            + " table_name VARCHAR(255) NOT NULL,"
+                            + " prop_key VARCHAR(255) NOT NULL,"
+                            + " prop_value TEXT,"
+                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, database_name, table_name, prop_key))");
+                    // synclite_checkpoint tracks per-device replication progress on the destination.
+                    // Bootstrap it here so recovery reads/writes never race with the first
+                    // ensureDstMetadataInitStatusColumn call, which runs on an executor thread after
+                    // device discovery and would otherwise find the table missing.
+                    String checkpointTbl = qualifiedDstTableName("synclite_checkpoint");
+                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + checkpointTbl
+                            + "(synclite_device_id TEXT NOT NULL,"
+                            + " synclite_device_name TEXT NOT NULL,"
+                            + " synclite_update_timestamp TEXT,"
+                            + " commit_id BIGINT NOT NULL,"
+                            + " cdc_change_number BIGINT NOT NULL,"
+                            + " cdc_log_segment_sequence_number BIGINT NOT NULL,"
+                            + " initialization_status INTEGER NOT NULL DEFAULT 0,"
+                            + " txn_count BIGINT NOT NULL,"
+                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))");
+                }
+                dstMetadataTableEnsured = true;
+                dstTableMetadataTableEnsured = true;
+            } catch (SQLException e) {
+                throw new SyncLiteException("Failed to bootstrap destination metadata tables", e);
+            }
+        }
         try {
             String strVal = getStringProperty("initialized_snapshot_name");
             if (strVal != null) {
@@ -708,8 +893,9 @@ public class ConsolidatorMetadataManager extends MetadataManager {
     private void resetDestinationDeviceStatus() throws SQLException {
         try (Connection conn = JDBCConnector.getInstance(dstIndex).connect()) {
             conn.setAutoCommit(false);
+            String qcheckpoint = qualifiedDstTableName("synclite_checkpoint");
             try (Statement stmt = conn.createStatement()) {
-                stmt.execute("CREATE TABLE IF NOT EXISTS synclite_checkpoint("
+                stmt.execute("CREATE TABLE IF NOT EXISTS " + qcheckpoint + "("
                         + "synclite_device_id TEXT NOT NULL, "
                         + "synclite_device_name TEXT NOT NULL, "
                         + "synclite_update_timestamp TEXT, "
@@ -721,7 +907,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
                         + "PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))");
             }
             try (PreparedStatement updateStmt = conn.prepareStatement(
-                    "UPDATE synclite_checkpoint SET initialization_status = 0 WHERE synclite_device_id = ? AND synclite_device_name = ?")) {
+                    "UPDATE " + qcheckpoint + " SET initialization_status = 0 WHERE synclite_device_id = ? AND synclite_device_name = ?")) {
                 updateStmt.setString(1, this.device.getDeviceUUID());
                 updateStmt.setString(2, this.device.getDeviceName());
                 updateStmt.execute();
@@ -733,9 +919,11 @@ public class ConsolidatorMetadataManager extends MetadataManager {
     }
 
 	public void executeCheckpointTableSql(String sql) throws SyncLiteException {
+		device.tracer.debug("[CHECKPOINT] Executing SQL on LOCAL checkpoint table: " + sql);
         try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + metadataFilePath)) {
         	try (Statement stmt = conn.createStatement()) {
         		stmt.execute(sql);
+        		device.tracer.debug("[CHECKPOINT] LOCAL checkpoint table SQL executed successfully");
         	}
         } catch(SQLException e) {
         	throw new DstExecutionException("Failed to execute checkpoint table sql : " + e.getMessage(), e);
@@ -743,6 +931,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
 	}
 
 	public void executeCheckpointTablePreparedStmt(String sql, ArrayList<Object> args) throws SyncLiteException {
+		device.tracer.debug("[CHECKPOINT] Executing prepared statement on LOCAL checkpoint table with " + args.size() + " args");
         try (Connection conn = DriverManager.getConnection("jdbc:sqlite:" + metadataFilePath)) {
         	try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
         		int i = 1;
@@ -751,6 +940,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         			++i;
         		}
         		pstmt.execute();
+        		device.tracer.debug("[CHECKPOINT] LOCAL checkpoint prepared statement executed successfully");
         	}
         } catch(SQLException e) {
         	throw new DstExecutionException("Failed to execute checkpoint table sql : " + e.getMessage(), e);
@@ -767,6 +957,9 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             			for (int i=1; i <=colCnt; ++i) {
             				result.put(rs.getMetaData().getColumnName(i).toLowerCase(), rs.getObject(i));
             			}
+            			device.tracer.debug("[READ] Checkpoint record read from LOCAL metadata: " + result);
+            		} else {
+            			device.tracer.debug("[READ] No checkpoint record found in LOCAL metadata");
             		}
             	}
         	}

--- a/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
@@ -17,13 +17,30 @@
 package com.synclite.consolidator.global;
 
 import java.nio.file.Path;
+import java.sql.JDBCType;
 
+import com.synclite.consolidator.schema.Column;
+import com.synclite.consolidator.schema.ConsolidatorSrcTable;
+import com.synclite.consolidator.schema.DataType;
+import com.synclite.consolidator.schema.StorageClass;
 import com.synclite.consolidator.schema.TableID;
 
 public class SyncLiteConsolidatorInfo {
 
     public static TableID getCheckpointTableID(String deviceUUID, String deviceName, int dstIndex) {
         return TableID.from(deviceUUID, deviceName, dstIndex, "main", null, getSyncLiteCheckpointTableName());
+    }
+
+    public static ConsolidatorSrcTable getCheckpointTableSchema(String deviceUUID, String deviceName, int dstIndex) {
+        ConsolidatorSrcTable checkpoint = ConsolidatorSrcTable.from(getCheckpointTableID(deviceUUID, deviceName, dstIndex));
+        checkpoint.clearColumns();
+        checkpoint.setIsSystemTable();
+        checkpoint.addColumn(new Column(0, "commit_id", new DataType("LONG", JDBCType.BIGINT, StorageClass.NUMERIC), 1, null, 1, 0));
+        checkpoint.addColumn(new Column(1, "cdc_change_number", new DataType("LONG", JDBCType.BIGINT, StorageClass.NUMERIC), 1, null, 0, 0));
+        checkpoint.addColumn(new Column(2, "cdc_log_segment_sequence_number", new DataType("LONG", JDBCType.BIGINT, StorageClass.NUMERIC), 1, null, 0, 0));
+        checkpoint.addColumn(new Column(3, "initialization_status", new DataType("LONG", JDBCType.BIGINT, StorageClass.NUMERIC), 1, "0", 0, 0));
+        checkpoint.addColumn(new Column(4, "txn_count", new DataType("LONG", JDBCType.BIGINT, StorageClass.NUMERIC), 1, null, 0, 0));
+        return checkpoint;
     }
 
     public static String getSyncLiteCheckpointTableName() {
@@ -36,6 +53,47 @@ public class SyncLiteConsolidatorInfo {
      */
     public static String getConsolidatorTableMetadataTableName() {
     	return "synclite_consolidator_table_metadata";
+    }
+
+    public static TableID getConsolidatorTableMetadataTableID(String deviceUUID, String deviceName, int dstIndex) {
+        return TableID.from(deviceUUID, deviceName, dstIndex, "main", null, getConsolidatorTableMetadataTableName());
+    }
+
+    public static ConsolidatorSrcTable getConsolidatorTableMetadataTableSchema(String deviceUUID, String deviceName, int dstIndex) {
+        ConsolidatorSrcTable tableMetadata = ConsolidatorSrcTable.from(getConsolidatorTableMetadataTableID(deviceUUID, deviceName, dstIndex));
+        tableMetadata.clearColumns();
+        tableMetadata.setIsSystemTable();
+        tableMetadata.addColumn(new Column(0, "database_name", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(1, "table_name", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(2, "prop_key", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(3, "prop_value", new DataType("text", JDBCType.LONGVARCHAR, StorageClass.TEXT), 0, null, 0, 0));
+        return tableMetadata;
+    }
+
+    public static String getConsolidatorMetadataTableName() {
+        return "synclite_consolidator_metadata";
+    }
+
+    public static boolean isSystemMetadataTable(String tableName) {
+        if (tableName == null) {
+            return false;
+        }
+        return getSyncLiteCheckpointTableName().equalsIgnoreCase(tableName)
+                || getConsolidatorTableMetadataTableName().equalsIgnoreCase(tableName)
+                || getConsolidatorMetadataTableName().equalsIgnoreCase(tableName);
+    }
+
+    public static TableID getConsolidatorMetadataTableID(String deviceUUID, String deviceName, int dstIndex) {
+        return TableID.from(deviceUUID, deviceName, dstIndex, "main", null, getConsolidatorMetadataTableName());
+    }
+
+    public static ConsolidatorSrcTable getConsolidatorMetadataTableSchema(String deviceUUID, String deviceName, int dstIndex) {
+        ConsolidatorSrcTable metadata = ConsolidatorSrcTable.from(getConsolidatorMetadataTableID(deviceUUID, deviceName, dstIndex));
+        metadata.clearColumns();
+        metadata.setIsSystemTable();
+        metadata.addColumn(new Column(0, "prop_key", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        metadata.addColumn(new Column(1, "prop_value", new DataType("text", JDBCType.LONGVARCHAR, StorageClass.TEXT), 0, null, 0, 0));
+        return metadata;
     }
 
     public static String getCreateConsolidatorTableMetadataTableSql() {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
@@ -81,6 +81,7 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 		ConfLoader.getInstance().blockTable(dstIndex, REPLAY_CHECKPOINT_TABLE);
 		initCheckpointTableIfNeeded();
 		device.updateDeviceStatus(DeviceStatus.SYNCING, "");
+		device.tracer.info("[INIT] DeviceConsolidator initialized for device: " + device.getDeviceName());
 	}
 
 	/**
@@ -93,10 +94,12 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 			// LOCAL mode: create checkpoint table in local metadata file
 			try {
 				consolidatorMetadataMgr.executeCheckpointTableSql(createTxnTableSql);
+				device.tracer.debug("[INIT] Checkpoint table created in LOCAL metadata file");
 				HashMap<String, Object> checkpoint = consolidatorMetadataMgr.readCheckpointRecord(selectTxnTableSql);
 				if (checkpoint.isEmpty()) {
 					String insertSql = insertTxnTableSql.replace("$1", String.valueOf(this.lastConsolidatedCommitId));
 					consolidatorMetadataMgr.executeCheckpointTableSql(insertSql);
+					device.tracer.debug("[INIT] Initial checkpoint record inserted in LOCAL metadata file");
 				}
 			} catch (SyncLiteException e) {
 				throw new SyncLiteException("Failed to initialize the checkpoint table in SyncLite consolidator metadata file : ", e);
@@ -105,8 +108,10 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 			ConsolidatorSrcTable replicatorCheckpointTable = ConsolidatorSrcTable.from(
 					SyncLiteConsolidatorInfo.getCheckpointTableID(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex));
 			ConfLoader.getInstance().blockTable(dstIndex, replicatorCheckpointTable.id.table);
+		} else {
+			// DESTINATION mode: synclite_checkpoint lives on destination, created during snapshot consolidation
+			device.tracer.debug("[INIT] DESTINATION metadata mode: checkpoint will be read from/written to destination database");
 		}
-		// DESTINATION mode: synclite_checkpoint lives on destination, created during snapshot consolidation
 	}
 
 	private final void reloadCheckpointInfo() throws SyncLiteException {
@@ -124,7 +129,6 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 				throw new SyncLiteException("Failed to load consolidation src tables from metadata file : ", e);
 			}
 		}
-		seedInMemoryReplicaFromSchemas();
 
 		this.checkpointTable = ConsolidatorSrcTable.from(
 				SyncLiteConsolidatorInfo.getCheckpointTableID(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex));

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
@@ -168,7 +168,7 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 			}
 		}
 		device.updateLastReplicatedCommitID(this.lastConsolidatedCommitId);
-		device.tracer.info("Event streamer checkpoint recovered : dstIndex=" + dstIndex + " commitID=" + this.lastConsolidatedCommitId + " changeNumber=" + this.lastConsolidatedChangeNumberOnReplica);
+		device.tracer.info("Initial replica checkpoint state : dstIndex=" + dstIndex + " commitID=" + this.lastConsolidatedCommitId + " changeNumber=" + this.lastConsolidatedChangeNumberOnReplica);
 	}
 
 	
@@ -483,10 +483,12 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 				TableID prevTableId = null;
 				PreparedStatement replicaInsertPrepStmt = null;
 				boolean inTransaction = false;
+				boolean txnHasPostCheckpointWork = false;
 				while (log != null) {
 					if (log.isBegin()) {
 						inTransaction = true;
 						emptyTxn = true;
+						txnHasPostCheckpointWork = false;
 						currentInsertBatchCount = 0;
 						currentUpdateBatchCount = 0;
 						currentDeleteBatchCount = 0;
@@ -509,11 +511,20 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 							currentInsertBatchCountOnReplica = 0;
 						}
 
-						updateDstCheckpointIfNeeded(dstExecutor, log.commitId, log.changeNumber, beforeValues, afterValues);
-						beforeValues.clear();
-						afterValues.clear();
-						commitDstTran(dstExecutor);
-						updateLocalCheckpointIfNeeded(log.commitId, log.changeNumber);
+						if (txnHasPostCheckpointWork) {
+							updateDstCheckpointIfNeeded(dstExecutor, log.commitId, log.changeNumber, beforeValues, afterValues);
+							beforeValues.clear();
+							afterValues.clear();
+							commitDstTran(dstExecutor);
+							updateLocalCheckpointIfNeeded(log.commitId, log.changeNumber);
+						} else {
+							// Nothing was issued against dstExecutor for this source txn
+							// (e.g. all records filtered as already-applied on restart).
+							// Skip the no-op ROLLBACK+BEGIN cycle; keep the existing dst
+							// tx open for the next source txn.
+							beforeValues.clear();
+							afterValues.clear();
+						}
 
 						if (replicaConn != null) {
 							bindAndExecuteReplicaCheckpointUpdatePrepStmt(replicaCheckpointUpdatePrepStmt, log.commitId, log.changeNumber);
@@ -523,13 +534,17 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 							this.lastConsolidatedChangeNumberOnReplica = log.changeNumber;
 						}
 
-						++currentEventLogSegmentTxnCnt;
-						++consolidatedTxnCount;
-						this.lastConsolidatedCommitId = log.commitId;
-						this.lastConsolidatedChangeNumber = log.changeNumber;
+						if (txnHasPostCheckpointWork) {
+							++currentEventLogSegmentTxnCnt;
+							++consolidatedTxnCount;
+							this.lastConsolidatedCommitId = log.commitId;
+							this.lastConsolidatedChangeNumber = log.changeNumber;
+						}
 						emptyTxn = true;
 						inTransaction = false;
-						dstExecutor.beginTran();
+						if (txnHasPostCheckpointWork) {
+							dstExecutor.beginTran();
+						}
 
 						lastLog = log;
 						log = reader.readNextRecord();
@@ -727,6 +742,7 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 					
 					//Skip log based on lastConsolidated commitid and changenumber
 					if ((log.commitId > this.lastConsolidatedCommitId) || ((log.commitId == this.lastConsolidatedCommitId) && (log.changeNumber > this.lastConsolidatedChangeNumber))) {
+						txnHasPostCheckpointWork = true;
 						//
 						//Check if prevOper or prevTable is different than this log's oper and table..
 						//If yes then flush the existing batches

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceReplicator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceReplicator.java
@@ -368,8 +368,38 @@ public class DeviceReplicator extends DeviceProcessor {
 					this.processedTxnCount = 0;
 					this.currentCommandLogSegment = device.getCommandLogSegment(commandLogSegmentSequenceNumber);
 					if (this.currentCommandLogSegment == null) {
-						throw new SyncLiteException("Restart recovery failed. Command log segment with sequence number :" + commandLogSegmentSequenceNumber + " missing from the device");
-					}
+						// The persisted checkpoint may still be at the initial first-init state
+						// (seq=0, cdcSeq=0, commitID == replica's initial synclite_txn commit_id)
+						// when the device was registered but no sqllog has been published yet.
+						// In that case, tolerate the missing sqllog — first-init does the same
+						// (it inserts (0, initCommitID, 0) without requiring sqllog 0 to exist)
+						// and the replicator's normal loop waits for the first sqllog to arrive.
+						long replicaInitialCommitID = -1L;
+						try (ResultSet rsInit = stmt.executeQuery(firstCommitIDSql)) {
+							if (rsInit.next()) {
+								replicaInitialCommitID = rsInit.getLong(1);
+							}
+						} catch (SQLException ignored) {
+							// Best-effort: if we can't read the initial commit id we'll fall
+							// through to the strict failure below.
+						}
+						boolean atInitialState =
+								commandLogSegmentSequenceNumber == 0
+								&& cdcLogSegmentSequenceNumber == 0
+								&& this.commitID == replicaInitialCommitID;
+						if (!atInitialState) {
+							throw new SyncLiteException("Restart recovery failed. Command log segment with sequence number :" + commandLogSegmentSequenceNumber + " missing from the device");
+						}
+						device.tracer.info("Replay checkpoint at initial first-init state (no sqllog published yet) for device : " + device + "; waiting for first sqllog to arrive");
+						if (!isReplicationToSQLite()) {
+							this.currentCDCLogSegment = device.getCDCLogSegment(0);
+							if (this.currentCDCLogSegment == null) {
+								this.currentCDCLogSegment = device.getNewCDCLogSegment(0);
+							}
+							this.currentCDCLogSegment.load(this.commitID);
+						}
+						Monitor.getInstance().incrTotalSyncLiteTxnCnt(this.processedTxnCount);
+					} else {
 					device.tracer.info("Replay checkpoint recovered : commandlogSeq=" + commandLogSegmentSequenceNumber + " commitID=" + this.commitID + " cdclogSeq=" + cdcLogSegmentSequenceNumber);
 					if (!isReplicationToSQLite()) {
 						this.currentCDCLogSegment = device.getCDCLogSegment(cdcLogSegmentSequenceNumber);
@@ -382,6 +412,7 @@ public class DeviceReplicator extends DeviceProcessor {
 							Monitor.getInstance().incrTotalCommandLogSegmentCnt(this.currentCommandLogSegment.sequenceNumber + 1);
 						}
 						Monitor.getInstance().incrTotalSyncLiteTxnCnt(this.processedTxnCount);
+					}
 					} else {
 						device.tracer.debug("Initializing checkpoint table");
 						try (ResultSet rsFirstCommitID = stmt.executeQuery(firstCommitIDSql)) {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceSyncProcessor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceSyncProcessor.java
@@ -34,6 +34,7 @@ import com.synclite.consolidator.global.ConfLoader;
 import com.synclite.consolidator.global.MetadataRetry;
 import com.synclite.consolidator.global.ConsolidatorMetadataManager;
 import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
+import com.synclite.consolidator.oper.Delete;
 import com.synclite.consolidator.oper.Insert;
 import com.synclite.consolidator.oper.NativeOper;
 import com.synclite.consolidator.oper.Oper;
@@ -94,6 +95,8 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 
 	protected TableMapper userTableMapper;
 	protected TableMapper systemTableMapper;
+	protected final ConsolidatorSrcTable checkpointSystemTable;
+	protected final ConsolidatorSrcTable dstSchemaSystemTable;
 	protected final ConsolidatorMetadataManager consolidatorMetadataMgr;
 	protected DeviceStatsCollector statsCollector;
 	protected DeviceDstInitializer dstInitializer;
@@ -111,15 +114,31 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		super(device, dstIndex);
 		this.userTableMapper = TableMapper.getUserTableMapperInstance(dstIndex);
 		this.systemTableMapper = TableMapper.getSystemTableMapperInstance(dstIndex);
+		this.checkpointSystemTable = SyncLiteConsolidatorInfo.getCheckpointTableSchema(device.getDeviceUUID(), device.getDeviceName(), dstIndex);
+		this.dstSchemaSystemTable = SyncLiteConsolidatorInfo.getConsolidatorTableMetadataTableSchema(device.getDeviceUUID(), device.getDeviceName(), dstIndex);
 		this.consolidatorMetadataMgr = device.getConsolidatorMetadataMgr(dstIndex);
+		device.tracer.debug("[BOOT] Consolidator metadata manager initialized for device: " + device.getDeviceName());
 		this.statsCollector = device.getDeviceStatsCollector(dstIndex);
 		this.dstInitializer = new DeviceDstInitializer(device, userTableMapper, systemTableMapper, statsCollector, dstIndex);
 		this.dstInitializer.setSyncProcessor(this);
 		this.applyInsertIdempotently = ConfLoader.getInstance().getDstIdempotentDataIngestion(dstIndex);
 		String modeStr = ConfLoader.getInstance().getMetadataStore(dstIndex);
 		this.metadataStore = "LOCAL".equalsIgnoreCase(modeStr) ? MetadataStore.LOCAL : MetadataStore.DESTINATION;
+		device.tracer.debug("[BOOT] Metadata store mode set to: " + this.metadataStore);
 		ensureWorkDirExists();
 		initInMemoryReplica();
+	}
+
+	/**
+	 * Returns a schema-qualified table name for use in NativeOper SQL strings
+	 * that bypass the system table mapper. Matches ConsolidatorMetadataManager.qualifiedDstTableName.
+	 */
+	protected String qualifiedDstTableName(String tableName) {
+		String schema = ConfLoader.getInstance().getDstSchema(dstIndex);
+		if (schema != null && !schema.trim().isEmpty()) {
+			return "\"" + schema.replace("\"", "\"\"") + "\".\"" + tableName.replace("\"", "\"\"") + "\"";
+		}
+		return tableName;
 	}
 
 	// ── Abstract hook: return sequence number of current log segment ───────────
@@ -136,6 +155,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		try {
 			this.inMemoryReplicaConn = DriverManager.getConnection("jdbc:sqlite::memory:");
 			this.inMemoryReplicaConn.setAutoCommit(true);
+			device.tracer.debug("[BOOT] In-memory replica connection initialized");
 		} catch (SQLException e) {
 			throw new SyncLiteException("Failed to initialize in-memory replica connection", e);
 		}
@@ -146,7 +166,9 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 			java.nio.file.Path root = device.getDeviceDataRoot();
 			if (!Files.exists(root)) {
 				Files.createDirectories(root);
-				device.tracer.info("Created fresh workDir at : " + root);
+				device.tracer.info("[BOOT] Created fresh workDir at: " + root);
+			} else {
+				device.tracer.debug("[BOOT] WorkDir already exists at: " + root);
 			}
 		} catch (IOException e) {
 			throw new SyncLiteException("Failed to create workDir : " + device.getDeviceDataRoot(), e);
@@ -154,11 +176,14 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	}
 
 	protected final void seedInMemoryReplicaFromSchemas() throws SyncLiteException {
+		device.tracer.debug("[BOOT] Seeding in-memory replica from stored schemas");
 		try (Statement stmt = inMemoryReplicaConn.createStatement()) {
+			int tableCount = 0;
 			for (ConsolidatorSrcTable srcTable : consolidatorMetadataMgr.getConsolidatorSrcTables()) {
 				if (srcTable.sql != null && !srcTable.sql.isEmpty()) {
 					try {
 						stmt.execute(srcTable.sql);
+						tableCount++;
 					} catch (SQLException e) {
 						if (!e.getMessage().contains("already exists")) throw e;
 					}
@@ -188,11 +213,13 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 					sb.append(")");
 					try {
 						stmt.execute(sb.toString());
+						tableCount++;
 					} catch (SQLException e) {
 						if (!e.getMessage().contains("already exists")) throw e;
 					}
 				}
 			}
+			device.tracer.info("[BOOT] Seeded in-memory replica with " + tableCount + " tables");
 		} catch (SQLException e) {
 			throw new SyncLiteException("Failed to seed in-memory replica from stored schemas", e);
 		}
@@ -200,6 +227,11 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 
 	/** Populates checkpointTable.columns from the in-memory replica DDL when empty. */
 	protected final void reloadCheckpointTableColumns() throws SyncLiteException {
+		if (this.checkpointTable == null) {
+			this.checkpointTable = ConsolidatorSrcTable.from(
+					SyncLiteConsolidatorInfo.getCheckpointTableID(device.getDeviceUUID(), device.getDeviceName(), this.dstIndex));
+			this.checkpointTable.setIsSystemTable();
+		}
 		if (this.checkpointTable.columns.isEmpty()) {
 			try (Statement _stmt = inMemoryReplicaConn.createStatement()) {
 				_stmt.execute(createTxnTableSql);
@@ -220,16 +252,17 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 
 	// ── Initialization status on destination metadata ───────────────────────────
 
-	protected void ensureDstMetadataInitStatusColumn(SQLExecutor dstExecutor) throws DstExecutionException {
+	protected void ensureDstMetadataInitStatusColumn(SQLExecutor dstExecutor) throws DstExecutionException, SyncLiteException {
 		if (dstInitStatusColumnInitialized) return;
-		dstExecutor.execute(new NativeOper(null, createDstTxnTableSql));
+		dstExecutor.execute(systemTableMapper.mapOper(new com.synclite.consolidator.oper.CreateTable(checkpointSystemTable)));
 		boolean recreate = false;
+		String qcheckpoint = qualifiedDstTableName("synclite_checkpoint");
 		try {
 			dstExecutor.execute(new NativeOper(null,
-					"SELECT synclite_device_id, synclite_device_name, initialization_status FROM synclite_checkpoint WHERE 1 = 0"));
+					"SELECT synclite_device_id, synclite_device_name, initialization_status FROM " + qcheckpoint + " WHERE 1 = 0"));
 		} catch (DstExecutionException e) {
 			String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
-			if (msg.contains("no such column") || msg.contains("unknown column") || msg.contains("invalid identifier")) {
+			if (msg.contains("no such column") || msg.contains("unknown column") || msg.contains("invalid identifier") || msg.contains("does not exist")) {
 				recreate = true;
 			} else {
 				throw e;
@@ -238,33 +271,38 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		if (!recreate) {
 			try {
 				dstExecutor.execute(new NativeOper(null,
-						"SELECT command_log_change_number FROM synclite_checkpoint WHERE 1 = 0"));
+						"SELECT command_log_change_number FROM " + qcheckpoint + " WHERE 1 = 0"));
 				recreate = true;
 			} catch (DstExecutionException e) {
 				String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
-				if (!(msg.contains("no such column") || msg.contains("unknown column") || msg.contains("invalid identifier"))) {
+				if (!(msg.contains("no such column") || msg.contains("unknown column") || msg.contains("invalid identifier") || msg.contains("does not exist"))) {
 					throw e;
 				}
 			}
 		}
 		if (recreate) {
 			// Recreate incompatible or legacy checkpoint table schema in one shot (no ALTER path).
-			dstExecutor.execute(new NativeOper(null, "DROP TABLE IF EXISTS synclite_checkpoint"));
-			dstExecutor.execute(new NativeOper(null, createDstTxnTableSql));
+			dstExecutor.execute(new NativeOper(null, "DROP TABLE IF EXISTS " + qcheckpoint));
+			dstExecutor.execute(systemTableMapper.mapOper(new com.synclite.consolidator.oper.CreateTable(checkpointSystemTable)));
 		}
 		dstExecutor.commitTran();
 		dstExecutor.beginTran();
 		dstInitStatusColumnInitialized = true;
 	}
 
-	protected void persistInitializationStatusToDst(SQLExecutor dstExecutor, long status) throws DstExecutionException {
+	protected void persistInitializationStatusToDst(SQLExecutor dstExecutor, long status) throws DstExecutionException, SyncLiteException {
 		ensureDstMetadataInitStatusColumn(dstExecutor);
-		String uuid  = device.getDeviceUUID().replace("'", "''");
-		String dname = device.getDeviceName().replace("'", "''");
-		dstExecutor.execute(new NativeOper(null,
-				"UPDATE synclite_checkpoint SET initialization_status = " + status
-				+ " WHERE synclite_device_id = '" + uuid
-				+ "' AND synclite_device_name = '" + dname + "'"));
+		reloadCheckpointTableColumns();
+		List<Object> beforeValues = new ArrayList<Object>(1);
+		beforeValues.add(this.lastConsolidatedCommitId);
+		List<Object> afterValues = new ArrayList<Object>(1);
+		afterValues.add(status);
+		Update initStatusUpdate = new Update(checkpointSystemTable, beforeValues, afterValues);
+		initStatusUpdate.whereColumns = new ArrayList<Column>();
+		initStatusUpdate.whereColumns.add(getCheckpointColumn("commit_id"));
+		initStatusUpdate.setColumns = new ArrayList<Column>();
+		initStatusUpdate.setColumns.add(getCheckpointColumn("initialization_status"));
+		dstExecutor.execute(systemTableMapper.mapOper(initStatusUpdate));
 	}
 
 	/**
@@ -293,11 +331,12 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	 * Per-table source DDL is stored as {@code prop_key='create_sql'} rows in
 	 * {@code synclite_consolidator_table_metadata}.
 	 */
-	protected void ensureDstSchemaTableExists(SQLExecutor dstExecutor) throws DstExecutionException {
+	protected void ensureDstSchemaTableExists(SQLExecutor dstExecutor) throws DstExecutionException, SyncLiteException {
 		if (dstSchemaTableInitialized) return;
-		dstExecutor.execute(new NativeOper(null, SyncLiteConsolidatorInfo.getCreateConsolidatorTableMetadataTableSql()));
-		dstExecutor.commitTran();
-		dstExecutor.beginTran();
+		// synclite_consolidator_table_metadata is already bootstrapped once per device
+		// by ConsolidatorMetadataManager.initializeConsolidatorMetadataFile() (DESTINATION
+		// mode) via raw JDBC. Re-issuing CREATE TABLE IF NOT EXISTS here is redundant
+		// and shows up as per-DeviceSyncProcessor DDL spam in device traces.
 		dstSchemaTableInitialized = true;
 	}
 
@@ -345,39 +384,47 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 		}
 	}
 
-	protected void persistSchemaToDst(SQLExecutor dstExecutor, ConsolidatorSrcTable srcTable) throws DstExecutionException {
+	protected void persistSchemaToDst(SQLExecutor dstExecutor, ConsolidatorSrcTable srcTable) throws DstExecutionException, SyncLiteException {
 		ensureDstSchemaTableExists(dstExecutor);
-		String uuid  = device.getDeviceUUID().replace("'", "''");
-		String dname = device.getDeviceName().replace("'", "''");
-		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database).replace("'", "''");
-		String tname = srcTable.id.table.replace("'", "''");
+		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database);
+		String tname = srcTable.id.table;
 		// Always derive the DDL from the current column model — srcTable.sql is set once
 		// from the original CREATE on restart and never refreshed by apply*Column, so it
 		// would drift after any ADDCOLUMN / DROPCOLUMN / ALTERCOLUMN / RENAMECOLUMN.
-		String csql  = buildCreateSqlFromColumns(srcTable).replace("'", "''");
-		dstExecutor.execute(new NativeOper(null,
-				"DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = '" + uuid
-				+ "' AND device_name = '" + dname
-				+ "' AND database_name = '" + dbname
-				+ "' AND table_name = '" + tname
-				+ "' AND prop_key = 'create_sql'"));
-		dstExecutor.execute(new NativeOper(null,
-				"INSERT INTO synclite_consolidator_table_metadata(device_uuid, device_name, database_name, table_name, prop_key, prop_value) VALUES('"
-				+ uuid + "', '" + dname + "', '" + dbname + "', '" + tname + "', 'create_sql', '" + csql + "')"));
+		String csql  = buildCreateSqlFromColumns(srcTable);
+		List<Object> beforeValues = new ArrayList<Object>(3);
+		beforeValues.add(dbname);
+		beforeValues.add(tname);
+		beforeValues.add(SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+		Delete deleteCreateSql = new Delete(dstSchemaSystemTable, beforeValues);
+		deleteCreateSql.whereColumns = new ArrayList<Column>();
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("database_name"));
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("table_name"));
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("prop_key"));
+		dstExecutor.execute(systemTableMapper.mapOper(deleteCreateSql));
+
+		List<Object> afterValues = new ArrayList<Object>(4);
+		afterValues.add(dbname);
+		afterValues.add(tname);
+		afterValues.add(SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+		afterValues.add(csql);
+		dstExecutor.execute(systemTableMapper.mapOper(new Insert(dstSchemaSystemTable, afterValues, false)));
 	}
 
-	protected void deleteSchemaFromDst(SQLExecutor dstExecutor, ConsolidatorSrcTable srcTable) throws DstExecutionException {
+	protected void deleteSchemaFromDst(SQLExecutor dstExecutor, ConsolidatorSrcTable srcTable) throws DstExecutionException, SyncLiteException {
 		if (!dstSchemaTableInitialized) return;
-		String uuid  = device.getDeviceUUID().replace("'", "''");
-		String dname = device.getDeviceName().replace("'", "''");
-		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database).replace("'", "''");
-		String tname = srcTable.id.table.replace("'", "''");
-		dstExecutor.execute(new NativeOper(null,
-				"DELETE FROM synclite_consolidator_table_metadata WHERE device_uuid = '" + uuid
-				+ "' AND device_name = '" + dname
-				+ "' AND database_name = '" + dbname
-				+ "' AND table_name = '" + tname
-				+ "' AND prop_key = 'create_sql'"));
+		String dbname = (srcTable.id.database == null || srcTable.id.database.isEmpty() ? "main" : srcTable.id.database);
+		String tname = srcTable.id.table;
+		List<Object> beforeValues = new ArrayList<Object>(3);
+		beforeValues.add(dbname);
+		beforeValues.add(tname);
+		beforeValues.add(SyncLiteConsolidatorInfo.getCreateSqlPropKey());
+		Delete deleteCreateSql = new Delete(dstSchemaSystemTable, beforeValues);
+		deleteCreateSql.whereColumns = new ArrayList<Column>();
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("database_name"));
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("table_name"));
+		deleteCreateSql.whereColumns.add(dstSchemaSystemTable.colMap.get("prop_key"));
+		dstExecutor.execute(systemTableMapper.mapOper(deleteCreateSql));
 	}
 
 	protected String buildCreateSqlFromColumns(ConsolidatorSrcTable srcTable) {
@@ -442,6 +489,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	protected final List<Oper> prepareCheckpointUpdate(long commitIDToCheckpoint,
 			long changeNumberToCheckpoint,
 			List<Object> beforeValues, List<Object> afterValues) throws SyncLiteException {
+		reloadCheckpointTableColumns();
 		List<Object> checkpointBeforeValues = new ArrayList<Object>(1);
 		checkpointBeforeValues.add(this.lastConsolidatedCommitId);
 
@@ -463,6 +511,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	}
 
 	private Column getCheckpointColumn(String columnName) throws SyncLiteException {
+		reloadCheckpointTableColumns();
 		Column col = checkpointTable.colMap.get(columnName);
 		if (col == null) {
 			throw new SyncLiteException("Missing checkpoint column in synclite_checkpoint: " + columnName);
@@ -471,6 +520,7 @@ public abstract class DeviceSyncProcessor extends DeviceProcessor {
 	}
 
 	protected final List<Oper> prepareCheckpointInsert() throws SyncLiteException {
+		reloadCheckpointTableColumns();
 		List<Object> afterValues = new ArrayList<Object>();
 		afterValues.add(this.lastConsolidatedCommitId);
 		afterValues.add(this.lastConsolidatedChangeNumber);

--- a/root/core/src/main/java/com/synclite/consolidator/processor/JDBCExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/JDBCExecutor.java
@@ -113,6 +113,19 @@ public abstract class JDBCExecutor extends SQLExecutor {
 		}
 	}
 
+	/**
+	 * Returns a schema-qualified table name for use in raw SQL strings that bypass
+	 * the system table mapper, so PostgreSQL resolves them in the configured schema
+	 * instead of following search_path. Mirrors DeviceSyncProcessor.qualifiedDstTableName.
+	 */
+	protected String qualifiedDstTableName(String tableName) {
+		String schema = ConfLoader.getInstance().getDstSchema(dstIndex);
+		if (schema != null && !schema.trim().isEmpty()) {
+			return "\"" + schema.replace("\"", "\"\"") + "\".\"" + tableName.replace("\"", "\"\"") + "\"";
+		}
+		return tableName;
+	}
+
 
 	protected void bindInsertArgs(Insert oper) throws SQLException {
 		int i = 1;
@@ -1523,18 +1536,22 @@ public abstract class JDBCExecutor extends SQLExecutor {
 
 	@Override
 	protected CDCLogPosition readCDCLogPosition(String deviceUUID, String deviceName, ConsolidatorDstTable dstControlTable) throws DstExecutionException {
-		try (Statement stmt = conn.createStatement()) {
-			try (ResultSet rs = stmt.executeQuery(sqlGenerator.getCheckpointTableSelectSql(deviceUUID, deviceName, dstControlTable))) {
-				if (rs.next()) {
-					CDCLogPosition logPos = new CDCLogPosition(0, -1, 0, 0);
-					logPos.commitId = rs.getLong(1);
-					logPos.changeNumber = rs.getLong(2);
-					logPos.logSegmentSequenceNumber = rs.getLong(3);
-					logPos.txnCount = rs.getLong(4);
-					return logPos;
-				}
-				throw new DstExecutionException("No checkpoint log position found in the destination");
+		String uuid = deviceUUID.replace("'", "''");
+		String dname = deviceName.replace("'", "''");
+		String sql = "SELECT commit_id, cdc_change_number, cdc_log_segment_sequence_number, txn_count FROM "
+				+ qualifiedDstTableName("synclite_checkpoint")
+				+ " WHERE synclite_device_id = '" + uuid + "' AND synclite_device_name = '" + dname + "'"
+				+ " LIMIT 1";
+		try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql)) {
+			if (rs.next()) {
+				CDCLogPosition logPos = new CDCLogPosition(0, -1, 0, 0);
+				logPos.commitId = rs.getLong(1);
+				logPos.changeNumber = rs.getLong(2);
+				logPos.logSegmentSequenceNumber = rs.getLong(3);
+				logPos.txnCount = rs.getLong(4);
+				return logPos;
 			}
+			throw new DstExecutionException("No checkpoint log position found in the destination");
 		} catch (SQLException e) {
 			throw new DstExecutionException("Failed to read checkpoint log position from destination : " + e.getMessage(), e);
 		}
@@ -1543,8 +1560,9 @@ public abstract class JDBCExecutor extends SQLExecutor {
 	@Override
 	public List<String[]> readTableSchemas(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {
 		List<String[]> schemas = new ArrayList<>();
-		String sql = "SELECT database_name, table_name, prop_value FROM synclite_consolidator_table_metadata WHERE device_uuid = '"
-				+ deviceUUID.replace("'", "''") + "' AND device_name = '"
+		String sql = "SELECT database_name, table_name, prop_value FROM " + qualifiedDstTableName("synclite_consolidator_table_metadata")
+				+ " WHERE synclite_device_id = '"
+				+ deviceUUID.replace("'", "''") + "' AND synclite_device_name = '"
 				+ deviceName.replace("'", "''") + "' AND prop_key = 'create_sql'";
 		try (Statement stmt = conn.createStatement();
 				ResultSet rs = stmt.executeQuery(sql)) {
@@ -1561,7 +1579,8 @@ public abstract class JDBCExecutor extends SQLExecutor {
 	public long readInitializationStatus(String deviceUUID, String deviceName, int dstIdx) throws DstExecutionException {
 		String uuid = deviceUUID.replace("'", "''");
 		String dname = deviceName.replace("'", "''");
-		String sql = "SELECT initialization_status FROM synclite_checkpoint WHERE synclite_device_id = '"
+		String sql = "SELECT initialization_status FROM " + qualifiedDstTableName("synclite_checkpoint")
+				+ " WHERE synclite_device_id = '"
 				+ uuid + "' AND synclite_device_name = '" + dname + "' ORDER BY commit_id DESC LIMIT 1";
 		try (Statement stmt = conn.createStatement(); ResultSet rs = stmt.executeQuery(sql)) {
 			if (rs.next()) {
@@ -1569,6 +1588,12 @@ public abstract class JDBCExecutor extends SQLExecutor {
 			}
 			return -1;
 		} catch (SQLException e) {
+			// Table may not exist yet (first time this device is seen on a fresh destination).
+			// Return -1 so caller treats it as "not initialized" and proceeds to initialize.
+			String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
+			if (msg.contains("does not exist") || msg.contains("no such table") || msg.contains("unknown table")) {
+				return -1;
+			}
 			throw new DstExecutionException("Failed to read initialization status from destination : " + e.getMessage(), e);
 		}
 	}

--- a/root/core/src/main/java/com/synclite/consolidator/schema/ConsolidationTableMapper.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/ConsolidationTableMapper.java
@@ -80,7 +80,7 @@ public class ConsolidationTableMapper extends TableMapper {
 
         boolean hasPK = false;
         for (Column srcColumn : srcTable.columns) {
-        	if (! ConfLoader.getInstance().isAllowedColumn(dstIndex, srcTable.id.table, srcColumn.column)) {
+            if (!srcTable.getIsSystemTable() && !ConfLoader.getInstance().isAllowedColumn(dstIndex, srcTable.id.table, srcColumn.column)) {
         		continue;
         	}
             Column dstColumn;
@@ -111,6 +111,9 @@ public class ConsolidationTableMapper extends TableMapper {
 
     @Override
     protected TableID mapTableID(TableID srcTableID) {
+		if (SyncLiteConsolidatorInfo.isSystemMetadataTable(srcTableID.table)) {
+			return TableID.from(srcTableID.deviceUUID, srcTableID.deviceName, this.dstIndex, ConfLoader.getInstance().getDstDatabase(dstIndex), ConfLoader.getInstance().getDstSchema(dstIndex), srcTableID.table);
+		}
 		String mappedTableName = ConfLoader.getInstance().getMappedTableName(dstIndex, srcTableID.table);
         return TableID.from(srcTableID.deviceUUID, srcTableID.deviceName, this.dstIndex, ConfLoader.getInstance().getDstDatabase(dstIndex), ConfLoader.getInstance().getDstSchema(dstIndex), mappedTableName);
     }

--- a/root/core/src/main/java/com/synclite/consolidator/schema/TableMapper.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/TableMapper.java
@@ -19,10 +19,14 @@ package com.synclite.consolidator.schema;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.log4j.Logger;
 
 import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.global.ConfLoader;
+import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
 import com.synclite.consolidator.oper.AddColumn;
 import com.synclite.consolidator.oper.AlterColumn;
 import com.synclite.consolidator.oper.BeginTran;
@@ -52,8 +56,12 @@ import com.synclite.consolidator.oper.UpdateIfPredicate;
 import com.synclite.consolidator.oper.Upsert;
 
 public abstract class TableMapper {
-		
-	private static final class InstanceHolder {
+
+    private static final Logger LOG = Logger.getLogger(TableMapper.class);
+    // One-shot per (dstIndex, table) WARN guard so we don't spam the trace.
+    private static final Set<String> MISSING_PK_WARNED = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+
+    private static final class InstanceHolder {
 		private static final TableMapper USER_TM_INSTANCES[] = createUserTableMappers();
 		private static final TableMapper SYSTEM_TM_INSTANCES[] = createSystemTableMappers();
 
@@ -165,7 +173,10 @@ public abstract class TableMapper {
     }
 
     public Column mapColumn(TableID srcTableID, Column srcColumn) {
-		String mappedColumnName = ConfLoader.getInstance().getMappedColumnName(dstIndex, srcTableID.table, srcColumn.column);
+        if (SyncLiteConsolidatorInfo.isSystemMetadataTable(srcTableID.table)) {
+            return mapSystemColumn(srcColumn);
+        }
+        String mappedColumnName = ConfLoader.getInstance().getMappedColumnName(dstIndex, srcTableID.table, srcColumn.column);
     	Column dstColumn = new Column(
                 srcColumn.cid,
                 mappedColumnName,
@@ -372,9 +383,23 @@ public abstract class TableMapper {
         		case DELETE_INSERT:
         			return new DeleteInsert(dstTable, dstValues, dstValues);
         		}
+        	} else {
+        		warnMissingPrimaryKeyOnce(dstTable);
         	}
         }
         return new Insert(dstTable, dstValues, false);
+    }
+
+    private void warnMissingPrimaryKeyOnce(ConsolidatorDstTable dstTable) {
+        String tableKey = (dstTable.id != null) ? dstTable.id.toString() : String.valueOf(dstTable);
+        String guardKey = dstIndex + "::" + tableKey;
+        if (MISSING_PK_WARNED.add(guardKey)) {
+            LOG.warn("dst-idempotent-data-ingestion is enabled for dstIndex=" + dstIndex
+                    + " but destination table '" + tableKey + "' has no primary key; "
+                    + "falling back to plain INSERT. Re-ingesting the same source rows will produce duplicates. "
+                    + "Declare a primary key on the source table to enable "
+                    + ConfLoader.getInstance().getDstIdempotentDataIngestionMethod(dstIndex) + ".");
+        }
     }
     
 }


### PR DESCRIPTION
# PR Description

## Summary
Hardens restart, destination-metadata, and idempotent-ingest correctness in the Java consolidator. Primary deployment target is PostgreSQL with `metadata-store=DESTINATION`, but several fixes (idempotent-ingest WARN, restart replay no-op trimming, replicator first-init tolerance) apply to all destinations.

## Problems Fixed
1. Unqualified raw SQL against consolidator system tables could resolve to the wrong PostgreSQL schema (depended on `search_path`).
2. Destination metadata tables and the destination checkpoint table were being created / validated too late and on every hot-path call.
3. Initialization-status persistence could throw a null-pointer when checkpoint schema metadata had not yet been loaded.
4. Event-streamer restart recovery could read the correct destination checkpoint and still replay already-consolidated transactions from the same log segment.
5. On restart-replay of an already-applied segment, the event-streamer emitted a noisy `BEGIN / ROLLBACK / BEGIN / ROLLBACK …` pair per filtered source txn, even though no statement had been issued to the destination.
6. `dst-idempotent-data-ingestion-N=true` silently fell through to plain `INSERT` when the destination table had no primary key, producing duplicates on every re-replay with no operator-visible signal.
7. The SQLite-replicator (`DeviceReplicator`) treated a registered-but-unwritten device as "restart recovery failed" — a freshly registered device whose first sqllog had not yet been published would fail to start the replay loop.
8. Destination checkpoint recovery and schema caching paths needed stronger fresh-host behavior after work-dir resets.

## Implementation Details

### Destination metadata hardening (PostgreSQL focus)
- Schema-qualified raw SQL handling for all consolidator system tables (`synclite_consolidator_metadata`, `synclite_consolidator_table_metadata`, `synclite_checkpoint`).
- One-time destination metadata + checkpoint bootstrap on startup when running in destination metadata mode.
- Tightened PostgreSQL-oriented metadata access so raw SQL follows the configured `dst-schema` instead of implicit `search_path` resolution.

### Checkpoint lifecycle and recovery
- Lazy checkpoint-table initialization in shared sync-processor paths so initialization-status writes are safe before the full checkpoint reload.
- Destination checkpoint recovery is strict: the device row is expected and read from the configured schema-qualified checkpoint table.
- `DeviceEventStreamer` no longer regresses the in-memory `(commitID, changeNumber)` baseline while scanning pre-checkpoint records during replay.
- Early event-streamer log lines now distinguish local replica bootstrap state from destination checkpoint recovery state.

### Restart-replay trace cleanup (`DeviceEventStreamer.doApply`)
- When every record in a source txn was filtered as already-applied (i.e. the COMMIT branch fires with `txnHasPostCheckpointWork == false`), the destination connection no longer issues a no-op `rollbackTran()` followed by a re-`beginTran()`.
- The connection stays open in `autoCommit=false`, ready for the next real txn. This drastically reduces noise in `synclite_consolidator.trace` on restart, and removes pointless round-trips against destinations like PostgreSQL.

### Idempotent-ingest visibility (`TableMapper.getMappedInsertOper`)
- When `dst-idempotent-data-ingestion-N=true` but the destination table has no primary key, the code still has to fall back to plain `INSERT` (the only correct option), but now emits a **one-shot WARN** per `(dstIndex, table)` describing the situation and the configured method (`NATIVE_UPSERT` / `NATIVE_REPLACE` / `DELETE_INSERT`). De-duplication uses a process-wide `ConcurrentHashMap`-backed set, so each affected table warns exactly once per JVM run.
- This surfaces the silent duplicate-rows-on-replay scenario that previously required correlating sqllog segments with destination row counts to diagnose.

### SQLite-replicator restart tolerance (`DeviceReplicator.initCheckpointTable`)
- A registered device whose persisted checkpoint is still at the initial first-init state (`seq=0, cdcSeq=0, commitID == replica's initial synclite_txn commit_id`) and whose sqllog 0 is not yet on disk is now treated as "waiting for first sqllog", not as restart recovery failure.
- The replicator initializes the in-memory CDC log segment (when replicating to a non-SQLite destination) and enters the normal wait-for-sqllog loop, mirroring what first-init does on a brand-new device.

### Recovery and schema propagation
- Strengthened destination schema-table loading for fresh-host recovery.
- Destination initialization status is loaded back before sync continues.
- Bootstrap / metadata work happens once where practical to reduce repeated hot-path DDL.

## Files Changed
- `root/core/src/main/java/com/synclite/consolidator/global/ConfLoader.java`
- `root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java`
- `root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java`
- `root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java`
- `root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java`
- `root/core/src/main/java/com/synclite/consolidator/processor/DeviceReplicator.java`
- `root/core/src/main/java/com/synclite/consolidator/processor/DeviceSyncProcessor.java`
- `root/core/src/main/java/com/synclite/consolidator/processor/JDBCExecutor.java`
- `root/core/src/main/java/com/synclite/consolidator/schema/ConsolidationTableMapper.java`
- `root/core/src/main/java/com/synclite/consolidator/schema/TableMapper.java`
