### PR TITLE
Hardening of destination backed checkpoint handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Default credentials (Tomcat manager): `synclite` / `synclite`
 
 ```bash
 cd synclite-consolidator/root
-mvn -Drevision=oss clean install
+mvn -Drevision=1.0.0 clean install
 ```
 
 Built WAR: `root/web/target/synclite-consolidator-oss.war`

--- a/root/core/pom.xml
+++ b/root/core/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<properties>
-		<revision>oss</revision>
+		<revision>1.0.0</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>

--- a/root/core/src/main/java/com/synclite/consolidator/exception/DstErrorClassifier.java
+++ b/root/core/src/main/java/com/synclite/consolidator/exception/DstErrorClassifier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.synclite.consolidator.exception;
+
+import java.sql.SQLException;
+import java.sql.SQLTransientException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLRecoverableException;
+
+public final class DstErrorClassifier {
+
+    private DstErrorClassifier() {}
+
+    /**
+     * Returns true when {@code t} (or any cause in its chain) looks like a
+     * destination-wide / transient infrastructure failure: connection lost,
+     * cannot reach destination, auth/admin shutdown, deadlock, serialization
+     * failure, resource exhaustion, or socket/IO timeout.
+     *
+     * Used by the segment-apply loops to decide whether
+     * {@code dst-skip-failed-log-files=true} should be honored after
+     * retries are exhausted. The skip flag is meant for poison-pill segments
+     * (bad data, missing table/column, syntax) — not for outages, where
+     * skipping silently advances past every subsequent segment and loses
+     * data. When this returns true, the caller must NOT skip; the next
+     * processor cycle will retry the same segment.
+     */
+    public static boolean isTransientDstError(Throwable t) {
+        Throwable cur = t;
+        while (cur != null) {
+            if (cur instanceof SQLTransientException
+                    || cur instanceof SQLRecoverableException
+                    || cur instanceof SQLNonTransientConnectionException
+                    || cur instanceof java.net.SocketException
+                    || cur instanceof java.net.SocketTimeoutException
+                    || cur instanceof java.net.UnknownHostException
+                    || cur instanceof java.net.ConnectException
+                    || cur instanceof java.io.InterruptedIOException) {
+                return true;
+            }
+            if (cur instanceof SQLException) {
+                String state = ((SQLException) cur).getSQLState();
+                if (state != null && state.length() >= 2) {
+                    String cls = state.substring(0, 2);
+                    // 08 = Connection Exception, 40 = Transaction Rollback (incl. deadlock),
+                    // 53 = Insufficient Resources, 57 = Operator Intervention (incl. admin/crash shutdown, cannot_connect_now)
+                    if (cls.equals("08") || cls.equals("40") || cls.equals("53") || cls.equals("57")) {
+                        return true;
+                    }
+                }
+            }
+            String msg = cur.getMessage();
+            if (msg != null) {
+                String lm = msg.toLowerCase();
+                if (lm.contains("connection refused")
+                        || lm.contains("connection reset")
+                        || lm.contains("connection closed")
+                        || lm.contains("connection timed out")
+                        || lm.contains("broken pipe")
+                        || lm.contains("network is unreachable")
+                        || lm.contains("no route to host")
+                        || lm.contains("could not connect")
+                        || lm.contains("server closed the connection")
+                        || lm.contains("an i/o error occurred while sending")
+                        || lm.contains("deadlock")) {
+                    return true;
+                }
+            }
+            Throwable next = cur.getCause();
+            if (next == cur) {
+                break;
+            }
+            cur = next;
+        }
+        return false;
+    }
+}

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
@@ -33,6 +33,7 @@ import java.util.List;
 import com.synclite.consolidator.device.Device;
 import com.synclite.consolidator.device.DeviceStatus;
 import com.synclite.consolidator.exception.DstDuplicateKeyException;
+import com.synclite.consolidator.exception.DstErrorClassifier;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.global.ConfLoader;
@@ -309,7 +310,22 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 						}
 						if (i == (ConfLoader.getInstance().getDstOperRetryCount(dstIndex)-1)) {
 							Boolean skipFailedLogSegments = ConfLoader.getInstance().getDstSkipFailedLogFiles(dstIndex);
-							if (!skipFailedLogSegments) {
+							// dst-skip-failed-log-files is for poison-pill segments (bad data,
+							// missing table/column, syntax). Refuse to honor it for transient
+							// destination outages (connection / deadlock / admin shutdown /
+							// resource exhaustion) — skipping would silently advance past every
+							// subsequent segment and cause data loss. Halt instead; the next
+							// processor cycle retries the same segment when the dst is reachable.
+							boolean transient_ = DstErrorClassifier.isTransientDstError(e);
+							if (!skipFailedLogSegments || transient_) {
+								if (skipFailedLogSegments && transient_) {
+									device.tracer.error("NOT skipping cdc log segment : " + currentCDCLogSegment
+											+ " on dst : " + dstIndex
+											+ " despite dst-skip-failed-log-files=true: error appears to be "
+											+ "a transient / destination-connectivity issue. Skipping would "
+											+ "silently advance past every subsequent segment and lose data. "
+											+ "The same segment will be retried on the next processor cycle.", e);
+								}
 								throw new SyncLiteException("Dst txn failed after all retry attempts : ", e);
 							} else {
 								skipLogSegment(currentCDCLogSegment);

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
@@ -36,6 +36,7 @@ import com.synclite.consolidator.SyncDriver;
 import com.synclite.consolidator.device.Device;
 import com.synclite.consolidator.device.DeviceStatus;
 import com.synclite.consolidator.exception.DstDuplicateKeyException;
+import com.synclite.consolidator.exception.DstErrorClassifier;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
 import com.synclite.consolidator.global.ConfLoader;
@@ -369,7 +370,19 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 						if (i == (ConfLoader.getInstance().getDstOperRetryCount(dstIndex)-1)) {
 							device.tracer.error("Dst txn failed after all retry attempts : ", e);
 							Boolean skipFailedLogSegments = ConfLoader.getInstance().getDstSkipFailedLogFiles(dstIndex);
-							if (!skipFailedLogSegments) {
+							// See DeviceConsolidator: the skip flag must NOT mask a transient
+							// destination outage, or we silently lose data on every segment
+							// processed while the dst stays unreachable.
+							boolean transient_ = DstErrorClassifier.isTransientDstError(e);
+							if (!skipFailedLogSegments || transient_) {
+								if (skipFailedLogSegments && transient_) {
+									device.tracer.error("NOT skipping event log segment : " + currentEventLogSegment
+											+ " on dst : " + this.dstIndex
+											+ " despite dst-skip-failed-log-files=true: error appears to be "
+											+ "a transient / destination-connectivity issue. Skipping would "
+											+ "silently advance past every subsequent segment and lose data. "
+											+ "The same segment will be retried on the next processor cycle.", e);
+								}
 								throw new SyncLiteException("Dst txn failed after all retry attempts : ", e);
 							} else {
 								skipAndMarkApplied(currentEventLogSegment);
@@ -518,12 +531,18 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 							commitDstTran(dstExecutor);
 							updateLocalCheckpointIfNeeded(log.commitId, log.changeNumber);
 						} else {
-							// Nothing was issued against dstExecutor for this source txn
-							// (e.g. all records filtered as already-applied on restart).
-							// Skip the no-op ROLLBACK+BEGIN cycle; keep the existing dst
-							// tx open for the next source txn.
+							// Source committed an empty txn (or all records were
+							// filtered as already-applied on restart). Still
+							// advance the destination checkpoint so the source-truth
+							// commit_id from synclite_txn lines up with the
+							// destination's synclite_checkpoint -- otherwise
+							// awaitSync waits forever on a commit_id that no
+							// data row will ever bring.
 							beforeValues.clear();
 							afterValues.clear();
+							updateDstCheckpointIfNeeded(dstExecutor, log.commitId, log.changeNumber, beforeValues, afterValues);
+							commitDstTran(dstExecutor);
+							updateLocalCheckpointIfNeeded(log.commitId, log.changeNumber);
 						}
 
 						if (replicaConn != null) {
@@ -534,17 +553,13 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 							this.lastConsolidatedChangeNumberOnReplica = log.changeNumber;
 						}
 
-						if (txnHasPostCheckpointWork) {
-							++currentEventLogSegmentTxnCnt;
-							++consolidatedTxnCount;
-							this.lastConsolidatedCommitId = log.commitId;
-							this.lastConsolidatedChangeNumber = log.changeNumber;
-						}
+						++currentEventLogSegmentTxnCnt;
+						++consolidatedTxnCount;
+						this.lastConsolidatedCommitId = log.commitId;
+						this.lastConsolidatedChangeNumber = log.changeNumber;
 						emptyTxn = true;
 						inTransaction = false;
-						if (txnHasPostCheckpointWork) {
-							dstExecutor.beginTran();
-						}
+						dstExecutor.beginTran();
 
 						lastLog = log;
 						log = reader.readNextRecord();

--- a/root/pom.xml
+++ b/root/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>root</artifactId>
 	<version>${revision}</version>
 	<properties>
-		<revision>oss</revision>
+		<revision>1.0.0</revision>
 	</properties>
 	<packaging>pom</packaging>
 

--- a/root/web/pom.xml
+++ b/root/web/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>synclite-consolidator</artifactId>
 	<version>${revision}</version>
 	<properties>
-		<revision>oss</revision>
+		<revision>1.0.0</revision>
 	</properties>
 	<packaging>war</packaging>
 	<parent>


### PR DESCRIPTION
This change set hardens destination-backed checkpoint handling, restart-replay behavior, and idempotent-ingest visibility across the Java consolidator and the Rust consolidator runtime/state crates.

The primary user-visible fixes are:
- Restart correctness in `metadata-store=DESTINATION` mode (no more replaying already-consolidated transactions after the destination checkpoint has been recovered).
- Clean restart-replay traces — the Java event-streamer no longer emits empty `BEGIN/ROLLBACK` pairs for pre-checkpoint source transactions.
- An operator-visible WARN (both Java and Rust) when `dst-idempotent-data-ingestion` is enabled but the destination table has no primary key, so the silent duplicate-rows-on-replay scenario can no longer go undiagnosed.
- Restart tolerance for SQLite-replicator devices that were registered but never published a sqllog.
- Tightened PostgreSQL system-table access — schema-qualified raw SQL throughout, instead of depending on `search_path`.
