### PR TITLE
Various bug fixes

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
@@ -43,6 +43,7 @@ import com.synclite.consolidator.processor.SQLExecutor;
 import com.synclite.consolidator.schema.Column;
 import com.synclite.consolidator.schema.ConsolidatorSrcTable;
 import com.synclite.consolidator.schema.DataType;
+import com.synclite.consolidator.schema.SQLGenerator;
 import com.synclite.consolidator.schema.TableID;
 import com.synclite.consolidator.schema.TableMapper;
 import com.synclite.consolidator.watchdog.Monitor;
@@ -466,15 +467,13 @@ public class ConsolidatorMetadataManager extends MetadataManager {
 
     /**
      * Returns a schema-qualified reference to a destination system metadata table name
-     * (e.g. "myschema"."synclite_consolidator_metadata") when dst-schema is configured,
-     * or the bare name when no schema is configured. Used for raw JDBC SQL strings that
-     * bypass the system table mapper so PostgreSQL resolves them in the right schema
-     * instead of following search_path (which defaults to public).
+     * using the current destination SQL generator so the quoting style matches the target
+     * backend (e.g. MySQL backticks vs PostgreSQL double quotes).
      */
     private String qualifiedDstTableName(String tableName) {
         String schema = ConfLoader.getInstance().getDstSchema(dstIndex);
         if (schema != null && !schema.trim().isEmpty()) {
-            return "\"" + schema.replace("\"", "\"\"") + "\".\"" + tableName.replace("\"", "\"\"") + "\"";
+            return SQLGenerator.getInstance(dstIndex).getSchemaQualifiedObjectName(schema, tableName);
         }
         return tableName;
     }

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceConsolidator.java
@@ -431,10 +431,23 @@ public class DeviceConsolidator extends DeviceSyncProcessor {
 									
 									tableMapper = srcTable.getIsSystemTable() ? systemTableMapper : userTableMapper;
 									valueMapper = tableMapper.getValueMapper();
-									HashMap<OperType, Long> opStats = tableStats.get(tableId);										
+									// Rename-table stats should be attributed to the original table identity so the existing row is updated.
+											TableID statsTableId = tableId;
+											if (opType == OperType.RENAMETABLE) {
+												try (PreparedStatement renameTableSchemaReaderPstmt = conn.prepareStatement(CDCLogSegment.cdcLogSchemaReaderSql)) {
+													renameTableSchemaReaderPstmt.setLong(1, changeNumber);
+													try (ResultSet rsSchema = renameTableSchemaReaderPstmt.executeQuery()) {
+														if (rsSchema.next()) {
+															String oldTableName = rsSchema.getString(8);
+															statsTableId = DeviceStatsCollector.resolveStatsTableId(tableId, opType, oldTableName);
+														}
+													}
+												}
+											}
+											HashMap<OperType, Long> opStats = tableStats.get(statsTableId);										
 									if (opStats == null) {
 										opStats = new HashMap<OperType, Long>();
-										tableStats.put(tableId, opStats);
+										tableStats.put(statsTableId, opStats);
 									}
 									boolean ddlIgnoredInConsolidation =
 											(ConfLoader.getInstance().getDstSyncMode() == DstSyncMode.CONSOLIDATION)

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
@@ -608,12 +608,17 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 						tableId =  TableID.from(device.getDeviceUUID(), device.getDeviceName(),  this.dstIndex, log.databaseName, null, log.tableName);						
 					}
 					srcTable = ConsolidatorSrcTable.from(tableId);
+					// Rename-table stats should be attributed to the original table identity so the existing row is updated.
+					TableID statsTableId = tableId;
+					if (log.opType == OperType.RENAMETABLE && log.ddlInfo != null && log.ddlInfo.oldTableName != null) {
+						statsTableId = DeviceStatsCollector.resolveStatsTableId(tableId, log.opType, log.ddlInfo.oldTableName);
+					}
 					TableMapper tableMapper = srcTable.getIsSystemTable() ? this.systemTableMapper : this.userTableMapper;
 					ValueMapper valueMapper = tableMapper.getValueMapper();
-					HashMap<OperType, Long> opStats = tableStats.get(tableId);
+					HashMap<OperType, Long> opStats = tableStats.get(statsTableId);
 					if (opStats == null) {
 						opStats = new HashMap<OperType, Long>();
-						tableStats.put(tableId, opStats);
+						tableStats.put(statsTableId, opStats);
 					}
 					// In consolidation mode, DROP COLUMN and DROP TABLE are intentionally ignored
 					// (other devices may still use the column/table). Skip stats and log INFO.

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
@@ -56,8 +56,8 @@ public class DeviceStatsCollector {
 	private final String resetInitilizationStatsCollectedSql = "UPDATE device_statistics SET is_initialization_stats_collected = 0 WHERE dst_alias = '$'";
 	private final String createStatsTableSql = "CREATE TABLE IF NOT EXISTS table_statistics(dst_alias TEXT, database_name TEXT, schema_name TEXT, table_name TEXT, initial_rows LONG, insert_rows LONG, update_rows LONG, delete_rows LONG, add_column LONG, drop_column LONG, rename_column LONG, create_table LONG, drop_table LONG, rename_table LONG, PRIMARY KEY(dst_alias, database_name, schema_name, table_name))";
 	private final String insertStatsTableSql = "INSERT OR REPLACE INTO table_statistics(dst_alias, database_name, schema_name, table_name, initial_rows, insert_rows, update_rows, delete_rows, add_column, drop_column, rename_column, create_table, drop_table, rename_table) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-	private final String updateStatsTableSql = "UPDATE table_statistics SET insert_rows = insert_rows + ?, update_rows = update_rows + ?, delete_rows = delete_rows + ?, add_column = add_column + ?, drop_column = drop_column + ?, rename_column = rename_column + ?, create_table = create_table + ?, drop_table = drop_table + ?, rename_table = rename_table + ? WHERE dst_alias = ? AND database_name = ? AND table_name = ?";
-	private final String deleteStatsTableSql = "DELETE FROM table_statistics WHERE dst_alias = ? AND database_name = ? AND table_name = ?";
+	private final String updateStatsTableSql = "UPDATE table_statistics SET insert_rows = insert_rows + ?, update_rows = update_rows + ?, delete_rows = delete_rows + ?, add_column = add_column + ?, drop_column = drop_column + ?, rename_column = rename_column + ?, create_table = create_table + ?, drop_table = drop_table + ?, rename_table = rename_table + ? WHERE dst_alias = ? AND database_name = ? AND schema_name = ? AND table_name = ?";
+	private final String deleteStatsTableSql = "DELETE FROM table_statistics WHERE dst_alias = ? AND database_name = ? AND schema_name = ? AND table_name = ?";
 	private final String selectStatsTableSql = "SELECT database_name, schema_name, table_name FROM table_statistics WHERE dst_alias = '$';";
 	private final String deleteAllStatsTableSql = "DELETE FROM table_statistics WHERE dst_alias = '$'";
 
@@ -219,7 +219,8 @@ public class DeviceStatsCollector {
 
 						updateStatsTablePstmt.setString(10, this.dstAlias);
 						updateStatsTablePstmt.setString(11, database);
-						updateStatsTablePstmt.setString(12, table);
+						updateStatsTablePstmt.setString(12, schema);
+						updateStatsTablePstmt.setString(13, table);
 
 						if (opType == OperType.INSERT) {
 							updateStatsTablePstmt.setLong(1, opCount);
@@ -282,6 +283,13 @@ public class DeviceStatsCollector {
 		}
 	}
 
+	protected static TableID resolveStatsTableId(TableID tableId, OperType opType, String oldTableName) {
+		if (tableId != null && opType == OperType.RENAMETABLE && oldTableName != null && !oldTableName.isEmpty()) {
+			return TableID.from(tableId.deviceUUID, tableId.deviceName, tableId.dstIndex, tableId.database, tableId.schema, oldTableName);
+		}
+		return tableId;
+	}
+
 	private OperType normalizeStatsOperType(OperType opType) {
 		if (ConfLoader.getInstance().getDstSyncMode() == DstSyncMode.CONSOLIDATION) {
 			if (opType == OperType.DROPTABLE || opType == OperType.DROPCOLUMN) {
@@ -323,8 +331,9 @@ public class DeviceStatsCollector {
 				}
 
 				deleteStatsTablePstmt.setString(1, this.dstAlias);
-				deleteStatsTablePstmt.setString(2, entry.getKey().id.database);						
-				deleteStatsTablePstmt.setString(3, entry.getKey().id.table);
+				deleteStatsTablePstmt.setString(2, entry.getKey().id.database);
+				deleteStatsTablePstmt.setString(3, entry.getKey().id.schema);
+				deleteStatsTablePstmt.setString(4, entry.getKey().id.table);
 				deleteStatsTablePstmt.addBatch();
 				deleteBatchIsFilled = true;
 				

--- a/root/core/src/main/java/com/synclite/consolidator/schema/JDBCSQLGenerator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/JDBCSQLGenerator.java
@@ -340,16 +340,19 @@ public abstract class JDBCSQLGenerator extends SQLGenerator {
 	protected boolean pkHasNullableCols(Table tbl) {
         for (Column c : tbl.columns) {
             if (c.pkIndex > 0) {
-            	if (c.isNotNull == 0) {
-            		return true;
-            	}
+                if (isColumnNullable(c)) {
+                    return true;
+                }
             }
         }
         return false;
 	}
 
+    protected boolean isColumnNullable(Column c) {
+        return c.pkIndex == 0 && c.isNotNull == 0;
+    }
 
-	protected String getPKColList(Table tbl) {
+    protected String getPKColList(Table tbl) {
         StringBuilder builder = new StringBuilder();
         boolean first = true;
         for (Column c : tbl.columns) {
@@ -361,8 +364,7 @@ public abstract class JDBCSQLGenerator extends SQLGenerator {
                 first = false;
             }
         }
-        String pkList = builder.toString();
-        return pkList;
+        return builder.toString();
     }
     
     protected String getPrimaryKeySQL(Table tbl) {
@@ -416,8 +418,9 @@ public abstract class JDBCSQLGenerator extends SQLGenerator {
 
     protected String getColumnTypeSQLNoConstraint(Column c) {
     	// SQLite allows typeless columns; default to VARCHAR for any SQL destination.
-    	return (c.type.dbNativeDataType != null && !c.type.dbNativeDataType.isBlank())
-    			? c.type.dbNativeDataType : "VARCHAR";
+    	String typeName = (c.type.dbNativeDataType != null && !c.type.dbNativeDataType.isBlank())
+			? c.type.dbNativeDataType : "VARCHAR";
+    	return typeName;
     }
 
     protected String getColumnDefaultConstraint(Column c) {
@@ -434,7 +437,8 @@ public abstract class JDBCSQLGenerator extends SQLGenerator {
     			? c.type.dbNativeDataType : "VARCHAR";
     	builder.append(typeName);
         builder.append(" ");
-        if (c.isNotNull == 0) {
+        boolean notNull = c.isNotNull != 0 || c.pkIndex > 0;
+        if (!notNull) {
             builder.append(" NULL ");
         } else {
             builder.append(" NOT NULL ");

--- a/root/core/src/main/java/com/synclite/consolidator/schema/SQLGenerator.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/SQLGenerator.java
@@ -176,10 +176,17 @@ protected String quoteObjectNameIfNeeded(String item) {
         return quoteObjectNameIfNeeded(id.table);
     }
 
-    protected String quote(String item) {
-    	return "\"" + item + "\""; 
+    public String getSchemaQualifiedObjectName(String schema, String objectName) {
+        if (schema == null || schema.trim().isEmpty()) {
+            return quoteObjectNameIfNeeded(objectName);
+        }
+        return quoteObjectNameIfNeeded(schema) + "." + quoteObjectNameIfNeeded(objectName);
     }
-    
+
+    protected String quote(String item) {
+        return "\"" + item + "\"";
+    }
+
     public String getFullColumnNameSQL(TableID tblID, Column c) {
         return getTableNameSQL(tblID) + "." + getColumnNameSQL(c);
     }

--- a/root/core/src/test/java/com/synclite/consolidator/schema/SQLGeneratorTest.java
+++ b/root/core/src/test/java/com/synclite/consolidator/schema/SQLGeneratorTest.java
@@ -1,13 +1,16 @@
 package com.synclite.consolidator.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
+import java.sql.JDBCType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.synclite.consolidator.global.ConfLoader;
+import com.synclite.consolidator.oper.CreateTable;
 import com.synclite.consolidator.oper.RenameTable;
 
 class SQLGeneratorTest {
@@ -19,6 +22,7 @@ class SQLGeneratorTest {
         setBooleanArray(confLoader, "dstQuoteColumnNames", new Boolean[] { false, false });
         setBooleanArray(confLoader, "dstUseCatalogScopeResolution", new Boolean[] { false, true });
         setBooleanArray(confLoader, "dstUseSchemaScopeResolution", new Boolean[] { false, true });
+        setStringArray(confLoader, "dstCreateTableSuffix", new String[] { "", "" });
     }
 
     @Test
@@ -35,7 +39,42 @@ class SQLGeneratorTest {
         assertEquals("ALTER TABLE newdb.newschema.t1 RENAME TO t2", generator.getRenameTableSQL(renameTable));
     }
 
+    @Test
+    void schemaQualifiedObjectNamesUseDestinationSpecificQuoting() throws Exception {
+        ConfLoader confLoader = ConfLoader.getInstance();
+        setBooleanArray(confLoader, "dstQuoteObjectNames", new Boolean[] { false, true });
+
+        MySQLSQLGenerator mysqlGenerator = new MySQLSQLGenerator(1);
+        PGSQLGenerator postgresGenerator = new PGSQLGenerator(1);
+
+        assertEquals("`myschema`.`synclite_consolidator_metadata`",
+                mysqlGenerator.getSchemaQualifiedObjectName("myschema", "synclite_consolidator_metadata"));
+        assertEquals("\"myschema\".\"synclite_consolidator_metadata\"",
+                postgresGenerator.getSchemaQualifiedObjectName("myschema", "synclite_consolidator_metadata"));
+    }
+
+    @Test
+    void postgresCreateTableKeepsAutoincrementPrimaryKeyConstraint() {
+        PGSQLGenerator generator = new PGSQLGenerator(1);
+        Table table = new Table();
+        table.id = TableID.from("device-uuid", "device-name", 1, "newdb", "newschema", "items");
+        table.addColumn(new Column(1, "id", new DataType("INTEGER", JDBCType.INTEGER, StorageClass.INTEGER), 0, null, 1, 1));
+        table.addColumn(new Column(2, "name", new DataType("VARCHAR", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 0, 0));
+
+        CreateTable createTable = new CreateTable(table);
+        String sql = generator.getCreateTableSQL(createTable);
+
+        assertTrue(sql.contains("PRIMARY KEY(id)"));
+        assertTrue(sql.contains("id INTEGER"));
+    }
+
     private static void setBooleanArray(ConfLoader confLoader, String fieldName, Boolean[] values) throws Exception {
+        Field field = ConfLoader.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(confLoader, values);
+    }
+
+    private static void setStringArray(ConfLoader confLoader, String fieldName, String[] values) throws Exception {
         Field field = ConfLoader.class.getDeclaredField(fieldName);
         field.setAccessible(true);
         field.set(confLoader, values);


### PR DESCRIPTION
# PR Description -- synclite-consolidator

## Summary
This PR fixes a small set of runtime issues in the consolidator around destination metadata handling, rename-table stats tracking, and PostgreSQL DDL generation for idempotent upserts.

## Changes

### Metadata / SQL generation
- Updated metadata table qualification to use the destination SQL generator so schema-qualified names are quoted correctly for the target backend.
- Added destination-aware schema-qualified object naming in the shared SQL generator layer.

### Rename-table stats handling
- Fixed stats updates for rename-table operations so they are attributed to the original table identity rather than the new table name.
- Updated stats persistence to include schema in the update/delete predicates, avoiding mismatches across schemas.

### PostgreSQL compatibility
- Preserved primary-key constraints for SQLite-style autoincrement keys during DDL generation so PostgreSQL can build a valid conflict target for idempotent upserts.
- Added regression coverage for schema-qualified naming and PostgreSQL create-table PK generation.

## Validation
- Verified with `mvn -pl core test`
- Result: `BUILD SUCCESS` with 4 tests run, 0 failures, 0 errors, and 0 skipped.
