### PR TITLE
Fixes for column rename and automatic schema creation

### DIFF
--- a/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/ConsolidatorMetadataManager.java
@@ -36,6 +36,8 @@ import com.synclite.consolidator.connector.JDBCConnector;
 import com.synclite.consolidator.device.Device;
 import com.synclite.consolidator.exception.DstExecutionException;
 import com.synclite.consolidator.exception.SyncLiteException;
+import com.synclite.consolidator.oper.CreateDatabase;
+import com.synclite.consolidator.oper.CreateSchema;
 import com.synclite.consolidator.oper.CreateTable;
 import com.synclite.consolidator.oper.Delete;
 import com.synclite.consolidator.oper.Insert;
@@ -44,6 +46,7 @@ import com.synclite.consolidator.schema.Column;
 import com.synclite.consolidator.schema.ConsolidatorSrcTable;
 import com.synclite.consolidator.schema.DataType;
 import com.synclite.consolidator.schema.SQLGenerator;
+import com.synclite.consolidator.schema.Table;
 import com.synclite.consolidator.schema.TableID;
 import com.synclite.consolidator.schema.TableMapper;
 import com.synclite.consolidator.watchdog.Monitor;
@@ -112,15 +115,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             String tblMetaTbl = qualifiedDstTableName("synclite_consolidator_table_metadata");
             if (!dstTableMetadataTableEnsured) {
                 try (Statement ddl = conn.createStatement()) {
-                    ddl.execute("CREATE TABLE IF NOT EXISTS " + tblMetaTbl
-                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
-                            + " synclite_device_name VARCHAR(255) NOT NULL,"
-                            + " synclite_update_timestamp TEXT,"
-                            + " database_name VARCHAR(255) NOT NULL,"
-                            + " table_name VARCHAR(255) NOT NULL,"
-                            + " prop_key VARCHAR(255) NOT NULL,"
-                            + " prop_value TEXT,"
-                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, database_name, table_name, prop_key))");
+                    ddl.execute(buildSystemCreateTableSql(dstTableMetadataSystemTable));
                 }
                 dstTableMetadataTableEnsured = true;
             }
@@ -466,6 +461,20 @@ public class ConsolidatorMetadataManager extends MetadataManager {
     }
 
     /**
+     * Build a destination-correct {@code CREATE TABLE} statement for a SyncLite system table by
+     * routing its schema through the system table mapper and the per-destination SQL generator.
+     * This guarantees the column types, quoting, schema qualification and composite primary key
+     * are all valid for the target backend, instead of relying on hardcoded, destination-agnostic
+     * DDL. In particular MySQL rejects {@code TEXT}/{@code BLOB} columns inside a primary key and
+     * caps composite key length at 3072 bytes, both of which the mapper handles correctly (device
+     * columns map to bounded {@code char(n)} and numeric columns to {@code bigint}).
+     */
+    private String buildSystemCreateTableSql(ConsolidatorSrcTable systemSchema) {
+        Table dstTbl = systemTableMapper.mapTable(systemSchema);
+        return SQLGenerator.getInstance(dstIndex).getCreateTableSQL(new CreateTable(dstTbl));
+    }
+
+    /**
      * Returns a schema-qualified reference to a destination system metadata table name
      * using the current destination SQL generator so the quoting style matches the target
      * backend (e.g. MySQL backticks vs PostgreSQL double quotes).
@@ -610,13 +619,7 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             String metaTbl = qualifiedDstTableName("synclite_consolidator_metadata");
             if (!dstMetadataTableEnsured) {
                 try (Statement ddl = conn.createStatement()) {
-                    ddl.execute("CREATE TABLE IF NOT EXISTS " + metaTbl
-                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
-                            + " synclite_device_name VARCHAR(255) NOT NULL,"
-                            + " synclite_update_timestamp TEXT,"
-                            + " prop_key VARCHAR(255) NOT NULL,"
-                            + " prop_value TEXT,"
-                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, prop_key))");
+                    ddl.execute(buildSystemCreateTableSql(dstMetadataSystemTable));
                 }
                 dstMetadataTableEnsured = true;
             }
@@ -765,41 +768,20 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             try (Connection ddlConn = JDBCConnector.getInstance(dstIndex).connect()) {
                 ddlConn.setAutoCommit(true);
                 try (Statement ddlStmt = ddlConn.createStatement()) {
-                    // Build schema-qualified CREATE TABLE IF NOT EXISTS SQL directly so
-                    // PostgreSQL creates the tables in the configured schema, not search_path.
-                    String metaTbl = qualifiedDstTableName("synclite_consolidator_metadata");
-                    String tblMetaTbl = qualifiedDstTableName("synclite_consolidator_table_metadata");
-                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + metaTbl
-                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
-                            + " synclite_device_name VARCHAR(255) NOT NULL,"
-                            + " synclite_update_timestamp TEXT,"
-                            + " prop_key VARCHAR(255) NOT NULL,"
-                            + " prop_value TEXT,"
-                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, prop_key))");
-                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + tblMetaTbl
-                            + "(synclite_device_id VARCHAR(64) NOT NULL,"
-                            + " synclite_device_name VARCHAR(255) NOT NULL,"
-                            + " synclite_update_timestamp TEXT,"
-                            + " database_name VARCHAR(255) NOT NULL,"
-                            + " table_name VARCHAR(255) NOT NULL,"
-                            + " prop_key VARCHAR(255) NOT NULL,"
-                            + " prop_value TEXT,"
-                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, database_name, table_name, prop_key))");
+                    ensureDestinationNamespace(ddlStmt);
+                    // Route system-table DDL through the mapper + per-destination SQL generator so
+                    // column types, quoting, schema qualification and composite primary keys are all
+                    // valid for the target backend (e.g. MySQL rejects TEXT/BLOB columns in a primary
+                    // key and caps composite key length at 3072 bytes).
+                    ddlStmt.execute(buildSystemCreateTableSql(dstMetadataSystemTable));
+                    ddlStmt.execute(buildSystemCreateTableSql(dstTableMetadataSystemTable));
                     // synclite_checkpoint tracks per-device replication progress on the destination.
                     // Bootstrap it here so recovery reads/writes never race with the first
                     // ensureDstMetadataInitStatusColumn call, which runs on an executor thread after
                     // device discovery and would otherwise find the table missing.
-                    String checkpointTbl = qualifiedDstTableName("synclite_checkpoint");
-                    ddlStmt.execute("CREATE TABLE IF NOT EXISTS " + checkpointTbl
-                            + "(synclite_device_id TEXT NOT NULL,"
-                            + " synclite_device_name TEXT NOT NULL,"
-                            + " synclite_update_timestamp TEXT,"
-                            + " commit_id BIGINT NOT NULL,"
-                            + " cdc_change_number BIGINT NOT NULL,"
-                            + " cdc_log_segment_sequence_number BIGINT NOT NULL,"
-                            + " initialization_status INTEGER NOT NULL DEFAULT 0,"
-                            + " txn_count BIGINT NOT NULL,"
-                            + " PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))");
+                    ConsolidatorSrcTable checkpointSchema = SyncLiteConsolidatorInfo.getCheckpointTableSchema(
+                            device.getDeviceUUID(), device.getDeviceName(), dstIndex);
+                    ddlStmt.execute(buildSystemCreateTableSql(checkpointSchema));
                 }
                 dstMetadataTableEnsured = true;
                 dstTableMetadataTableEnsured = true;
@@ -846,6 +828,46 @@ public class ConsolidatorMetadataManager extends MetadataManager {
         Monitor.getInstance().incrInitializationCnt(this.initializationCount);
         Monitor.getInstance().registerChangedDevice(device);
 
+    }
+
+    /**
+     * Ensure the configured destination database and schema exist before the metadata /
+     * checkpoint tables are created. This is destination-agnostic: it delegates the actual
+     * existence-check and DDL SQL to the per-destination {@link SQLGenerator}, and honours
+     * each destination's {@code isDatabaseAllowed()} / {@code isSchemaAllowed()} capability
+     * flags (mirroring {@code JDBCExecutor.createDatabase} / {@code createSchema} and
+     * {@code DSTInitializer}), so no destination-specific SQL is hardcoded here.
+     *
+     * <p>Both operations are guarded by an existence check so they are idempotent even for
+     * destinations whose CREATE DATABASE / CREATE SCHEMA syntax has no IF NOT EXISTS clause.
+     */
+    private void ensureDestinationNamespace(Statement ddlStmt) throws SQLException {
+        SQLGenerator sqlGen = SQLGenerator.getInstance(dstIndex);
+        String database = ConfLoader.getInstance().getDstDatabase(dstIndex);
+        String schema = ConfLoader.getInstance().getDstSchema(dstIndex);
+
+        // Mock table carrying the configured destination database/schema so the generator
+        // can emit correctly-scoped existence-check and DDL SQL for this destination type.
+        Table nsTbl = new Table();
+        nsTbl.id = TableID.from(null, null, dstIndex, database, schema, "synclite_consolidator_metadata");
+
+        if (sqlGen.isDatabaseAllowed() && (database != null) && !database.trim().isEmpty()) {
+            if (!objectExists(ddlStmt, sqlGen.getDatabaseExistsCheckSQL(nsTbl))) {
+                ddlStmt.execute(sqlGen.getCreateDatabseSQL(new CreateDatabase(nsTbl)));
+            }
+        }
+
+        if (sqlGen.isSchemaAllowed() && (schema != null) && !schema.trim().isEmpty()) {
+            if (!objectExists(ddlStmt, sqlGen.getSchemaExistsCheckSQL(nsTbl))) {
+                ddlStmt.execute(sqlGen.getCreateSchemaSQL(new CreateSchema(nsTbl)));
+            }
+        }
+    }
+
+    private boolean objectExists(Statement ddlStmt, String checkSql) throws SQLException {
+        try (ResultSet rs = ddlStmt.executeQuery(checkSql)) {
+            return rs.next();
+        }
     }
     
     public void resetInitializedSnapshot() throws SyncLiteException {    	
@@ -894,16 +916,11 @@ public class ConsolidatorMetadataManager extends MetadataManager {
             conn.setAutoCommit(false);
             String qcheckpoint = qualifiedDstTableName("synclite_checkpoint");
             try (Statement stmt = conn.createStatement()) {
-                stmt.execute("CREATE TABLE IF NOT EXISTS " + qcheckpoint + "("
-                        + "synclite_device_id TEXT NOT NULL, "
-                        + "synclite_device_name TEXT NOT NULL, "
-                        + "synclite_update_timestamp TEXT, "
-                        + "commit_id LONG NOT NULL, "
-                        + "cdc_change_number LONG NOT NULL, "
-                        + "cdc_log_segment_sequence_number LONG NOT NULL, "
-                        + "initialization_status INTEGER NOT NULL DEFAULT 0, "
-                        + "txn_count LONG NOT NULL, "
-                        + "PRIMARY KEY(synclite_device_id, synclite_device_name, commit_id))");
+                // Route through the mapper + per-destination SQL generator so the checkpoint DDL is
+                // valid for the target backend (MySQL rejects TEXT columns in a primary key).
+                ConsolidatorSrcTable checkpointSchema = SyncLiteConsolidatorInfo.getCheckpointTableSchema(
+                        device.getDeviceUUID(), device.getDeviceName(), dstIndex);
+                stmt.execute(buildSystemCreateTableSql(checkpointSchema));
             }
             try (PreparedStatement updateStmt = conn.prepareStatement(
                     "UPDATE " + qcheckpoint + " SET initialization_status = 0 WHERE synclite_device_id = ? AND synclite_device_name = ?")) {

--- a/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
+++ b/root/core/src/main/java/com/synclite/consolidator/global/SyncLiteConsolidatorInfo.java
@@ -63,9 +63,9 @@ public class SyncLiteConsolidatorInfo {
         ConsolidatorSrcTable tableMetadata = ConsolidatorSrcTable.from(getConsolidatorTableMetadataTableID(deviceUUID, deviceName, dstIndex));
         tableMetadata.clearColumns();
         tableMetadata.setIsSystemTable();
-        tableMetadata.addColumn(new Column(0, "database_name", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
-        tableMetadata.addColumn(new Column(1, "table_name", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
-        tableMetadata.addColumn(new Column(2, "prop_key", new DataType("varchar(255)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(0, "database_name", new DataType("varchar(128)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(1, "table_name", new DataType("varchar(128)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
+        tableMetadata.addColumn(new Column(2, "prop_key", new DataType("varchar(128)", JDBCType.VARCHAR, StorageClass.TEXT), 1, null, 1, 0));
         tableMetadata.addColumn(new Column(3, "prop_value", new DataType("text", JDBCType.LONGVARCHAR, StorageClass.TEXT), 0, null, 0, 0));
         return tableMetadata;
     }
@@ -100,9 +100,9 @@ public class SyncLiteConsolidatorInfo {
     	return "CREATE TABLE IF NOT EXISTS synclite_consolidator_table_metadata("
     		+ "device_uuid VARCHAR(64) NOT NULL, "
     		+ "device_name VARCHAR(255) NOT NULL, "
-    		+ "database_name VARCHAR(255) NOT NULL, "
-    		+ "table_name VARCHAR(255) NOT NULL, "
-    		+ "prop_key VARCHAR(255) NOT NULL, "
+    		+ "database_name VARCHAR(128) NOT NULL, "
+    		+ "table_name VARCHAR(128) NOT NULL, "
+    		+ "prop_key VARCHAR(128) NOT NULL, "
     		+ "prop_value TEXT, "
     		+ "PRIMARY KEY(device_uuid, device_name, database_name, table_name, prop_key))";
     }

--- a/root/core/src/main/java/com/synclite/consolidator/log/CommandLogRecord.java
+++ b/root/core/src/main/java/com/synclite/consolidator/log/CommandLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.synclite.consolidator.log;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.synclite.consolidator.exception.SyncLiteException;
@@ -23,7 +24,7 @@ import com.synclite.consolidator.oper.OperType;
 
 public class CommandLogRecord {
 
-    public class DDLInfo {
+    public static class DDLInfo {
         public OperType ddlType;
         public String databaseName;
         public String tableName;
@@ -255,5 +256,19 @@ public class CommandLogRecord {
     @Override
     public String toString() {
         return "commit id : " + commitId + ", change number : " + changeNumber + ", sql : " + sql;
+    }
+
+    /**
+     * Static helper method to parse DDL from a SQL string without creating a full CommandLogRecord.
+     * Used for fallback DDL parsing when the event log SQL is not initially available.
+     */
+    public static DDLInfo parseDDLFromSQL(String sql) throws SyncLiteException {
+        if (sql == null || sql.trim().isEmpty()) {
+            return null;
+        }
+        
+        // Create a temporary instance and parse the SQL
+        CommandLogRecord tempRecord = new CommandLogRecord(0, 0, 0, sql, 0, new ArrayList<Object>());
+        return tempRecord.ddlInfo;
     }
 }

--- a/root/core/src/main/java/com/synclite/consolidator/processor/ClickHouseExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/ClickHouseExecutor.java
@@ -23,4 +23,9 @@ public class ClickHouseExecutor extends JDBCExecutor {
 		//
 		return false;	
 	}
+
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
 }

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceEventStreamer.java
@@ -45,6 +45,7 @@ import com.synclite.consolidator.global.DstSyncMode;
 import com.synclite.consolidator.global.SyncLiteConsolidatorInfo;
 import com.synclite.consolidator.global.SyncLiteLoggerInfo;
 import com.synclite.consolidator.log.CDCLogPosition;
+import com.synclite.consolidator.log.CommandLogRecord;
 import com.synclite.consolidator.log.CommandLogRecord.DDLInfo;
 import com.synclite.consolidator.log.EventLogRecord;
 import com.synclite.consolidator.log.EventLogSegment;
@@ -62,11 +63,14 @@ import com.synclite.consolidator.oper.Minus;
 import com.synclite.consolidator.oper.NativeOper;
 import com.synclite.consolidator.oper.Oper;
 import com.synclite.consolidator.oper.OperType;
+import com.synclite.consolidator.oper.RenameColumn;
+import com.synclite.consolidator.oper.RenameTable;
 import com.synclite.consolidator.oper.Update;
 import com.synclite.consolidator.oper.UpdateIfPredicate;
 import com.synclite.consolidator.schema.Column;
 import com.synclite.consolidator.schema.ConsolidatorDstTable;
 import com.synclite.consolidator.schema.ConsolidatorSrcTable;
+import com.synclite.consolidator.schema.RenameColumnPair;
 import com.synclite.consolidator.schema.Table;
 import com.synclite.consolidator.schema.TableID;
 import com.synclite.consolidator.schema.TableMapper;
@@ -623,7 +627,8 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 					if ((prevTableId != null) && (prevTableId.table.equals(log.tableName)) &&(prevTableId.database.equals(log.databaseName)))  {
 						tableId = prevTableId;
 					} else {
-						tableId =  TableID.from(device.getDeviceUUID(), device.getDeviceName(),  this.dstIndex, log.databaseName, null, log.tableName);						
+						// Normalize schema to empty string for consistency with DeviceStatsCollector stats lookup
+						tableId =  TableID.from(device.getDeviceUUID(), device.getDeviceName(),  this.dstIndex, log.databaseName, "", log.tableName);						
 					}
 					srcTable = ConsolidatorSrcTable.from(tableId);
 					// Rename-table stats should be attributed to the original table identity so the existing row is updated.
@@ -1456,36 +1461,74 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 								}
 								break;
 							case RENAMECOLUMN:
-								//executeDDLIgnoreException(log.sql);
-								String normalizedOldColumnName = normalizeIdentifier(log.ddlInfo.oldColumnName);
-							String normalizedNewColumnName = normalizeIdentifier(log.ddlInfo.columnName);
-							Oper renameColOper= srcTable.generateRenameColumnOper(normalizedOldColumnName, normalizedNewColumnName);
-								if (renameColOper != null) {
-									dstExecutor.execute(renameColOper.map(tableMapper));
-									tableMapper.remove(srcTable);
-									tblMappedInsertOpers.remove(srcTable.id);
-									tblMappedUpdateOpers.remove(srcTable.id);
-									tblMappedDeleteOpers.remove(srcTable.id);
-									try {
-										consolidatorMetadataMgr.upsertSchema(srcTable);
-									} catch (SQLException e) {
-										throw new SyncLiteException("Failed to persist schema for table : " + srcTable.id + " in consolidator metadata file : ", e);
+								// First try to use ddlInfo if available (from SQL parsing)
+								String normalizedOldColumnName = null;
+								String normalizedNewColumnName = null;
+								
+								if (log.ddlInfo != null && log.ddlInfo.oldColumnName != null && log.ddlInfo.columnName != null) {
+									// Use parsed DDL info
+									normalizedOldColumnName = normalizeIdentifier(log.ddlInfo.oldColumnName);
+									normalizedNewColumnName = normalizeIdentifier(log.ddlInfo.columnName);
+								} else {
+									// Fall back to detecting rename by comparing schema
+									newTableCols = device.schemaReader.fetchColumns(inMemoryReplicaConn, srcTable.id);
+									RenameColumnPair renameColPair = srcTable.detectRenameColumn(newTableCols);
+									if (renameColPair != null) {
+										normalizedOldColumnName = renameColPair.getOldColumnName();
+										normalizedNewColumnName = renameColPair.getNewColumnName();
 									}
-									persistSchemaAfterDDL(dstExecutor, srcTable);
+								}
+								
+								if (normalizedOldColumnName != null && normalizedNewColumnName != null) {
+									Oper renameColOper = srcTable.generateRenameColumnOper(normalizedOldColumnName, normalizedNewColumnName);
+									if (renameColOper != null) {
+										dstExecutor.execute(renameColOper.map(tableMapper));
+										tableMapper.remove(srcTable);
+										tblMappedInsertOpers.remove(srcTable.id);
+										tblMappedUpdateOpers.remove(srcTable.id);
+										tblMappedDeleteOpers.remove(srcTable.id);
+										try {
+											consolidatorMetadataMgr.upsertSchema(srcTable);
+										} catch (SQLException e) {
+											throw new SyncLiteException("Failed to persist schema for table : " + srcTable.id + " in consolidator metadata file : ", e);
+										}
+										persistSchemaAfterDDL(dstExecutor, srcTable);
+									}
 								}
 								break;
 							case RENAMETABLE:
-								String normalizedOldTableName = normalizeIdentifier(log.ddlInfo.oldTableName);
-							String normalizedNewTableName = normalizeIdentifier(log.ddlInfo.tableName);
-							Oper renameTableOper = srcTable.generateRenameTableOper(tableMapper, normalizedOldTableName, normalizedNewTableName);
-								if (renameTableOper != null) {
-									dstExecutor.execute(renameTableOper.map(tableMapper));
+								// First try to use ddlInfo if available (from SQL parsing)
+								String normalizedOldTableName = null;
+								String normalizedNewTableName = null;
+								
+								if (log.ddlInfo != null && log.ddlInfo.oldTableName != null && log.ddlInfo.tableName != null) {
+									// Use parsed DDL info
+									normalizedOldTableName = normalizeIdentifier(log.ddlInfo.oldTableName);
+									normalizedNewTableName = normalizeIdentifier(log.ddlInfo.tableName);
+								} else if (log.sql != null && !log.sql.isBlank()) {
+									// Try to parse SQL if ddlInfo not available
 									try {
-										consolidatorMetadataMgr.upsertSchema(srcTable);
-									} catch (SQLException e) {
-										throw new SyncLiteException("Failed to persist schema for table : " + srcTable.id + " in consolidator metadata file : ", e);
+										DDLInfo parsedDDL = CommandLogRecord.parseDDLFromSQL(log.sql);
+										if (parsedDDL != null && parsedDDL.oldTableName != null && parsedDDL.tableName != null) {
+											normalizedOldTableName = normalizeIdentifier(parsedDDL.oldTableName);
+											normalizedNewTableName = normalizeIdentifier(parsedDDL.tableName);
+										}
+									} catch (Exception e) {
+										device.tracer.debug("Failed to parse RENAME TABLE SQL: " + log.sql);
 									}
-									persistSchemaAfterDDL(dstExecutor, srcTable);
+								}
+								
+								if (normalizedOldTableName != null && normalizedNewTableName != null) {
+									Oper renameTableOper = srcTable.generateRenameTableOper(tableMapper, normalizedOldTableName, normalizedNewTableName);
+									if (renameTableOper != null) {
+										dstExecutor.execute(renameTableOper.map(tableMapper));
+										try {
+											consolidatorMetadataMgr.upsertSchema(srcTable);
+										} catch (SQLException e) {
+											throw new SyncLiteException("Failed to persist schema for table : " + srcTable.id + " in consolidator metadata file : ", e);
+										}
+										persistSchemaAfterDDL(dstExecutor, srcTable);
+									}
 								}
 								break;
 							case REFRESHTABLE:
@@ -1493,6 +1536,57 @@ public class DeviceEventStreamer extends DeviceSyncProcessor {
 								dstTable = tableMapper.mapTable(srcTable);
 								ConsolidatorDstTable.remove(dstTable.id);								
 								newTableCols = device.schemaReader.fetchColumns(inMemoryReplicaConn, srcTable.id);
+								// REFRESH TABLE carries a full schema snapshot. Reconcile destination schema
+								// by deriving concrete operations from old->new schema delta.
+								boolean schemaChanged = true;
+								int schemaGuard = 0;
+								int schemaGuardMax = (newTableCols != null ? newTableCols.size() : 0) + (srcTable.columns != null ? srcTable.columns.size() : 0) + 8;
+								if (schemaGuardMax < 16) {
+									schemaGuardMax = 16;
+								}
+
+								while (schemaChanged && (schemaGuard < schemaGuardMax)) {
+									schemaChanged = false;
+									++schemaGuard;
+
+									// Column renames are always delivered explicitly as ALTER TABLE RENAME COLUMN
+									// (OperType.RENAMECOLUMN) before the REFRESH TABLE in the dbreader pipeline, and
+									// are applied in-place preserving data. REFRESH TABLE is only a schema-sync
+									// safety net, so it must NOT re-derive renames heuristically here (doing so
+									// double-processes an already-applied rename and leaves both old and new columns).
+									Oper refreshAddColOper = srcTable.generateAddColumnOper(newTableCols);
+									if (refreshAddColOper != null) {
+										dstExecutor.execute(refreshAddColOper.map(tableMapper));
+										if (refreshAddColOper instanceof AddColumn) {
+											srcTable.applyAddColumn((AddColumn) refreshAddColOper);
+										}
+										schemaChanged = true;
+										continue;
+									}
+
+									Oper refreshDropColOper = srcTable.generateDropColumnOper(newTableCols);
+									if (refreshDropColOper != null) {
+										dstExecutor.execute(refreshDropColOper.map(tableMapper));
+										if (refreshDropColOper instanceof DropColumn) {
+											srcTable.applyDropColumn((DropColumn) refreshDropColOper);
+										}
+										schemaChanged = true;
+										continue;
+									}
+
+									Oper refreshAlterColOper = srcTable.generateAlterColumnOper(newTableCols);
+									if (refreshAlterColOper != null) {
+										dstExecutor.execute(refreshAlterColOper.map(tableMapper));
+										if (refreshAlterColOper instanceof AlterColumn) {
+											srcTable.applyAlterColumn((AlterColumn) refreshAlterColOper);
+										}
+										schemaChanged = true;
+									}
+								}
+
+								if (schemaGuard >= schemaGuardMax) {
+									device.tracer.warn("REFRESH TABLE reconciliation reached guard limit for table " + srcTable.id + ", applying final schema refresh only.");
+								}
 								//refresh schema for srcTable
 								srcTable.refreshColumns(tableMapper, newTableCols);
 								//Reload dst table

--- a/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/DeviceStatsCollector.java
@@ -108,6 +108,7 @@ public class DeviceStatsCollector {
 					while (rs.next()) {
 						String dbName = rs.getString(1);
 						String schemaName = rs.getString(2);
+						// Normalize schema to empty string (NULL from DB is normalized to "")
 						if (schemaName == null) schemaName = "";
 						String tableName = rs.getString(3);
 						TableID tblID = TableID.from(this.device.getDeviceUUID(), this.device.getDeviceName(), this.dstIndex, dbName, schemaName, tableName);
@@ -396,18 +397,20 @@ public class DeviceStatsCollector {
 	}
 
 	public final void resetTableStats() throws SyncLiteException {
+		// Preserve historical per-table counters across re-initialization/restarts.
+		// The old behavior deleted table_statistics and reset initialization flags,
+		// which caused all table rows/counters to appear as zero after restart.
 		String url = "jdbc:sqlite:" + this.statsFilePath;
-		try (Connection statsFileConn = DriverManager.getConnection(url)) {
+		try (Connection statsFileConn = DriverManager.getConnection(url);
+				 Statement stmt = statsFileConn.createStatement()) {
 			configureSqliteConnection(statsFileConn);
-			statsFileConn.setAutoCommit(false);
-			try (Statement stmt = statsFileConn.createStatement()) {
-				stmt.execute(deleteAllStatsTableSql.replace("$", this.dstAlias));
-				stmt.execute(resetInitilizationStatsCollectedSql.replace("$", this.dstAlias));
+			try (ResultSet rs = stmt.executeQuery(selectDeviceStatisticsTableSql.replace("$", this.dstAlias))) {
+				if (rs.next()) {
+					this.hasInitializationStatsCollected = rs.getLong(2);
+				}
 			}
-			statsFileConn.commit();
-			statsFileConn.setAutoCommit(true);
 		} catch (SQLException e) {
-			throw new SyncLiteException("Failed to delete table stats in stats file : " + statsFilePath, e);
+			throw new SyncLiteException("Failed to preserve table stats in stats file : " + statsFilePath, e);
 		}
 	}
 

--- a/root/core/src/main/java/com/synclite/consolidator/processor/MSSQLExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/MSSQLExecutor.java
@@ -46,4 +46,9 @@ public class MSSQLExecutor extends JDBCExecutor {
 		return false;
 	}
 
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
+
 }

--- a/root/core/src/main/java/com/synclite/consolidator/processor/MySQLExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/MySQLExecutor.java
@@ -47,4 +47,9 @@ public class MySQLExecutor extends JDBCExecutor {
 		}
 		return false;
 	}
+
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
 }

--- a/root/core/src/main/java/com/synclite/consolidator/processor/OracleExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/OracleExecutor.java
@@ -52,6 +52,11 @@ public class OracleExecutor extends JDBCExecutor {
 		return false;
 	}
 
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
+
 	//For oracle date comes as a timestamp. Try to set a timestamp.
 	@Override
 	protected void setDate(PreparedStatement pstmt, int i, Object o) throws SQLException {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/PGExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/PGExecutor.java
@@ -50,6 +50,10 @@ public class PGExecutor extends JDBCExecutor {
 		return false;
 	}
 
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
 	
 	protected void setDate(PreparedStatement pstmt, int i, Object o) throws SQLException {
 		try {

--- a/root/core/src/main/java/com/synclite/consolidator/processor/RedshiftExecutor.java
+++ b/root/core/src/main/java/com/synclite/consolidator/processor/RedshiftExecutor.java
@@ -44,4 +44,9 @@ public class RedshiftExecutor extends JDBCExecutor {
 		}
 		return false;
 	}
+
+	@Override
+	public boolean canCreateDatabase() {
+		return true;
+	}
 }

--- a/root/core/src/main/java/com/synclite/consolidator/schema/ConsolidatorSrcTable.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/ConsolidatorSrcTable.java
@@ -42,12 +42,47 @@ public class ConsolidatorSrcTable extends Table {
     }
 
     public void refreshColumns(TableMapper tableMapper, List<Column> newSchemaCols) {
+        preservePrimaryKeyMetadataIfMissing(newSchemaCols);
         //Clear off all columns of this table object in case the object is lying around
         //Clear off the table entry from the mapper in case its there from old instances of same table name
         tableMapper.remove(this);
         clearColumns();
         for (Column c : newSchemaCols) {
             addColumn(c);
+        }
+    }
+
+    private void preservePrimaryKeyMetadataIfMissing(List<Column> newSchemaCols) {
+        if (newSchemaCols == null || newSchemaCols.isEmpty()) {
+            return;
+        }
+
+        boolean refreshedHasPrimaryKey = false;
+        for (Column c : newSchemaCols) {
+            if (c.pkIndex > 0) {
+                refreshedHasPrimaryKey = true;
+                break;
+            }
+        }
+        if (refreshedHasPrimaryKey) {
+            return;
+        }
+
+        java.util.HashMap<String, Integer> existingPrimaryKeyIndexes = new java.util.HashMap<String, Integer>();
+        for (Column c : this.columns) {
+            if (c.pkIndex > 0) {
+                existingPrimaryKeyIndexes.put(c.column, c.pkIndex);
+            }
+        }
+        if (existingPrimaryKeyIndexes.isEmpty()) {
+            return;
+        }
+
+        for (Column c : newSchemaCols) {
+            Integer pkIndex = existingPrimaryKeyIndexes.get(c.column);
+            if (pkIndex != null) {
+                c.pkIndex = pkIndex;
+            }
         }
     }
 
@@ -121,6 +156,85 @@ public class ConsolidatorSrcTable extends Table {
         }
         renameColumn(renamedCol, newColName);
         return new RenameColumn(this, renamedCol, oldColName, newColName);
+    }
+
+    /**
+     * Detect a column rename by comparing new schema with current schema.
+     * Returns a RenameColumnPair if exactly one column was removed and one was added
+     * with matching types (suggesting a rename), otherwise returns null.
+     */
+    public RenameColumnPair detectRenameColumn(List<Column> newSchemaCols) {
+        if (newSchemaCols == null || newSchemaCols.isEmpty()) {
+            return null;
+        }
+
+        // Find columns that exist in current but not in new (removed columns)
+        java.util.List<Column> removedCols = new java.util.ArrayList<>();
+        for (Column c : this.columns) {
+            if (c.isSystemColumn) {
+                continue; // Skip system columns
+            }
+            boolean found = false;
+            for (Column newCol : newSchemaCols) {
+                if (newCol.column.equalsIgnoreCase(c.column)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                removedCols.add(c);
+            }
+        }
+
+        // Find columns that exist in new but not in current (added columns)
+        java.util.List<Column> addedCols = new java.util.ArrayList<>();
+        for (Column newCol : newSchemaCols) {
+            if (newCol.isSystemColumn) {
+                continue; // Skip system columns
+            }
+            boolean found = false;
+            for (Column c : this.columns) {
+                if (c.column.equalsIgnoreCase(newCol.column)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                addedCols.add(newCol);
+            }
+        }
+
+        // If exactly one column was removed and one was added, it might be a rename
+        if (removedCols.size() == 1 && addedCols.size() == 1) {
+            Column removed = removedCols.get(0);
+            Column added = addedCols.get(0);
+            
+            // Verify they have compatible column definitions before treating this as a rename.
+            if (isCompatibleRenameCandidate(removed, added)) {
+                return new RenameColumnPair(removed.column, added.column);
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isCompatibleRenameCandidate(Column removed, Column added) {
+        if (removed == null || added == null || removed.type == null || added.type == null) {
+            return false;
+        }
+        if (!removed.type.dbNativeDataType.equalsIgnoreCase(added.type.dbNativeDataType)) {
+            return false;
+        }
+        if (removed.isNotNull != added.isNotNull) {
+            return false;
+        }
+        if (removed.pkIndex != added.pkIndex) {
+            return false;
+        }
+        if (removed.isAutoIncrement != added.isAutoIncrement) {
+            return false;
+        }
+        return true;
     }
 
     public Oper generateRenameTableOper(TableMapper tableMapper, String oldTableName, String newTableName) {

--- a/root/core/src/main/java/com/synclite/consolidator/schema/MySQLDataTypeMapper.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/MySQLDataTypeMapper.java
@@ -76,9 +76,13 @@ public class MySQLDataTypeMapper extends DataTypeMapper {
 	@Override
     protected DataType doMapTypeForSystemColumn(DataType srcType) {
 		//
-		//We do this because MySQL does not support text column as PK , hence need to maint the char(n) columns like that only
+		//MySQL does not allow TEXT/BLOB columns in a PRIMARY KEY without a prefix length,
+		//so system columns that participate in composite primary keys must retain a bounded,
+		//fixed-or-variable width character type. Preserve char(n) and varchar(n) as-is instead
+		//of downgrading them to TEXT via best-effort mapping.
 		//
-        if (srcType.dbNativeDataType.toLowerCase().startsWith("char")) {
+        String nativeType = srcType.dbNativeDataType.toLowerCase();
+        if (nativeType.startsWith("char") || nativeType.startsWith("varchar")) {
 			return srcType;
 		} 
         return doMapTypeBestEffort(srcType);

--- a/root/core/src/main/java/com/synclite/consolidator/schema/RenameColumnPair.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/RenameColumnPair.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 mahendra.chavan@synclite.io, all rights reserved.
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.synclite.consolidator.schema;
+
+/**
+ * Simple DTO to hold information about a renamed column pair
+ */
+public class RenameColumnPair {
+    private String oldColumnName;
+    private String newColumnName;
+
+    public RenameColumnPair(String oldColumnName, String newColumnName) {
+        this.oldColumnName = oldColumnName;
+        this.newColumnName = newColumnName;
+    }
+
+    public String getOldColumnName() {
+        return oldColumnName;
+    }
+
+    public String getNewColumnName() {
+        return newColumnName;
+    }
+
+    @Override
+    public String toString() {
+        return "RenameColumnPair{" +
+                "oldColumnName='" + oldColumnName + '\'' +
+                ", newColumnName='" + newColumnName + '\'' +
+                '}';
+    }
+}

--- a/root/core/src/main/java/com/synclite/consolidator/schema/TableMapper.java
+++ b/root/core/src/main/java/com/synclite/consolidator/schema/TableMapper.java
@@ -297,17 +297,16 @@ public abstract class TableMapper {
 
     public List<Oper> mapOper(RenameColumn renameColumn) {
         ConsolidatorDstTable dstTable = mapTable((ConsolidatorSrcTable) renameColumn.tbl);
-        List<Column> dstColumnsToRename = new ArrayList<Column>(renameColumn.columns.size());
-        for (Column c : renameColumn.columns) {
-        	if (! ConfLoader.getInstance().isAllowedColumn(dstIndex, renameColumn.tbl.id.table, c.column)) {
-        		continue;
-        	}
-            dstColumnsToRename.add(mapColumn(renameColumn.tbl.id, c));
-        }
-        if (dstColumnsToRename.isEmpty()) {
+        if (! ConfLoader.getInstance().isAllowedColumn(dstIndex, renameColumn.tbl.id.table, renameColumn.oldName)) {
         	return Collections.EMPTY_LIST;
         }
-        return Collections.singletonList(new RenameColumn(dstTable, dstColumnsToRename.get(0), renameColumn.oldName, renameColumn.newName));
+
+        Column dstColumnToRename = dstTable.colMap.get(renameColumn.oldName);
+        if (dstColumnToRename == null) {
+            return Collections.EMPTY_LIST;
+        }
+
+        return Collections.singletonList(new RenameColumn(dstTable, dstColumnToRename, renameColumn.oldName, renameColumn.newName));
     }
 
     public List<Oper> mapOper(BeginTran beginTran) {


### PR DESCRIPTION
# PR Description - synclite-consolidator (fixes/renamefixes branch)

## Summary
This branch implements robust column and table rename detection with enhanced schema refresh reconciliation. It adds fallback mechanisms for detecting renames when DDL parsing is unavailable, preserves critical metadata during schema changes, and implements a safe iterative schema refresh process that prevents double-processing of rename operations.

## Key Features

### 1. **Robust Column Rename Detection**
- New `detectRenameColumn()` method in `ConsolidatorSrcTable` that:
  - Compares current schema with new schema to identify removed and added columns
  - Detects rename when exactly 1 column is removed and 1 is added
  - Validates compatibility: type, nullability, PK index, and auto-increment status must match
  - Returns `RenameColumnPair` DTO with old and new column names
- Falls back to schema comparison when DDL parsing fails
- First strategy: Use parsed DDL info → Second strategy: Schema comparison

### 2. **Metadata Preservation During Schema Refresh**
- New `preservePrimaryKeyMetadataIfMissing()` method ensures:
  - If refreshed schema lacks primary key information, existing PK indexes are preserved
  - Prevents loss of critical unique key constraints during schema updates
  - Handles null/blank metadata from schema readers gracefully

### 3. **Enhanced RENAMECOLUMN Operation**
- Dual-strategy approach:
  - Primary: Uses parsed `ddlInfo.oldColumnName` and `ddlInfo.columnName`
  - Fallback: Calls `detectRenameColumn()` to identify rename from schema comparison
- Executes rename operation and updates metadata
- Clears mapping cache and persists schema changes

### 4. **Enhanced RENAMETABLE Operation**
- Multi-strategy detection:
  - Primary: Uses `ddlInfo.oldTableName` and `ddlInfo.tableName`
  - Secondary: Parses SQL using `CommandLogRecord.parseDDLFromSQL()` if ddlInfo unavailable
  - Extracts table names from SQL when direct DDL info missing
- Robust fallback for DDL parsing failures

### 5. **Iterative Schema Refresh Reconciliation**
- `REFRESHTABLE` now uses safe, iterative schema sync:
  - Generates and applies schema delta operations in sequence: ADD COLUMN → DROP COLUMN → ALTER COLUMN
  - Uses guard mechanism (loop counter limit) to prevent infinite loops
  - **Critical:** Does NOT re-derive renames heuristically (renames are already applied earlier in pipeline)
  - Safely reconciles destination schema with new schema snapshot
- Phases-based updates: Each operation applied, then srcTable updated in-place
